### PR TITLE
Handle optional uploads without validation errors

### DIFF
--- a/hq_batch_store.php
+++ b/hq_batch_store.php
@@ -86,7 +86,27 @@ try {
 
     // Save HQ attachments (bank-in slip etc.)
     $dt = new DateTime($date ?: 'today');
-    $saved = (!empty($_FILES['hq_files']) ? save_hq_files($_FILES['hq_files'], $dt, $errors) : []);
+    $saved = [];
+    if (!empty($_FILES['hq_files']) && is_array($_FILES['hq_files']['name'])) {
+        $filtered = [
+            'name' => [],
+            'type' => [],
+            'tmp_name' => [],
+            'error' => [],
+            'size' => [],
+        ];
+        for ($i = 0, $n = count($_FILES['hq_files']['name']); $i < $n; $i++) {
+            if (($_FILES['hq_files']['error'][$i] ?? null) === UPLOAD_ERR_NO_FILE) { continue; }
+            $filtered['name'][]     = $_FILES['hq_files']['name'][$i];
+            $filtered['type'][]     = $_FILES['hq_files']['type'][$i];
+            $filtered['tmp_name'][] = $_FILES['hq_files']['tmp_name'][$i];
+            $filtered['error'][]    = $_FILES['hq_files']['error'][$i];
+            $filtered['size'][]     = $_FILES['hq_files']['size'][$i];
+        }
+        if (!empty($filtered['name'])) {
+            $saved = save_hq_files($filtered, $dt, $errors);
+        }
+    }
     if ($errors) { throw new RuntimeException(implode('; ', $errors)); }
 
     if ($saved) {

--- a/includes/upload_helpers.php
+++ b/includes/upload_helpers.php
@@ -47,6 +47,7 @@ function save_receipts(array $files, DateTime $dt, array &$err): array {
     // Normalize $_FILES multiple input
     $count = is_array($files['name']) ? count($files['name']) : 0;
     for ($i=0; $i<$count; $i++) {
+        if (($files['error'][$i] ?? null) === UPLOAD_ERR_NO_FILE) { continue; }
         $f = [
             'name'     => $files['name'][$i],
             'type'     => $files['type'][$i],
@@ -86,6 +87,7 @@ function save_hq_files(array $files, DateTime $dt, array &$err): array {
 
     $count = is_array($files['name']) ? count($files['name']) : 0;
     for ($i=0; $i<$count; $i++) {
+        if (($files['error'][$i] ?? null) === UPLOAD_ERR_NO_FILE) { continue; }
         $f = [
             'name'     => $files['name'][$i],
             'type'     => $files['type'][$i],

--- a/manager_submission_store.php
+++ b/manager_submission_store.php
@@ -81,6 +81,7 @@ if (BLOCK_DUPLICATES_PER_DATE && $outletId > 0 && $date) {
 $dt = new DateTime($date ?: 'today');
 if (!empty($_FILES['receipts']) && is_array($_FILES['receipts']['name'])) {
     for ($i=0, $n=count($_FILES['receipts']['name']); $i<$n; $i++) {
+        if (($_FILES['receipts']['error'][$i] ?? null) === UPLOAD_ERR_NO_FILE) { continue; }
         $tmp = [
             'name'     => $_FILES['receipts']['name'][$i],
             'type'     => $_FILES['receipts']['type'][$i],


### PR DESCRIPTION
## Summary
- skip validation for empty receipt and HQ upload slots before file handling
- filter out HQ no-file placeholders before saving attachments and continue surfacing real upload errors

## Testing
- php -l includes/upload_helpers.php
- php -l manager_submission_store.php
- php -l hq_batch_store.php
- php -r 'require "includes/upload_helpers.php"; $_SERVER["DOCUMENT_ROOT"]=getcwd(); $dt=new DateTime(); $errors=[]; $files=["name"=>["test.pdf"],"type"=>["application/pdf"],"tmp_name"=>["/tmp/fake"],"error"=>[UPLOAD_ERR_NO_FILE],"size"=>[0]]; var_export([save_receipts($files,$dt,$errors),$errors]);'
- php -r 'require "includes/upload_helpers.php"; $_SERVER["DOCUMENT_ROOT"]=getcwd(); $dt=new DateTime(); $errors=[]; $files=["name"=>["test.pdf"],"type"=>["application/pdf"],"tmp_name"=>["/tmp/fake"],"error"=>[UPLOAD_ERR_NO_FILE],"size"=>[0]]; var_export([save_hq_files($files,$dt,$errors),$errors]);'

------
https://chatgpt.com/codex/tasks/task_e_68dc759e653c832eb608181fe73c8cd6