### PR TITLE
Add account HQ package detail view and Excel export

### DIFF
--- a/account_hq_package_export.php
+++ b/account_hq_package_export.php
@@ -1,0 +1,157 @@
+<?php
+require __DIR__ . '/includes/auth.php';
+require_role(['account']);
+require __DIR__ . '/includes/db.php';
+
+$autoload = __DIR__ . '/vendor/autoload.php';
+if (!file_exists($autoload)) {
+    http_response_code(500);
+    echo 'Spreadsheet library not installed.';
+    exit;
+}
+require_once $autoload;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+$packageId = filter_input(INPUT_GET, 'package_id', FILTER_VALIDATE_INT);
+if (!$packageId) {
+    http_response_code(400);
+    echo 'Invalid package id.';
+    exit;
+}
+
+$sqlPackage = "SELECT p.*, "
+    . "creator.name AS created_by_name, "
+    . "approver.name AS approved_by_name "
+    . "FROM hq_packages p "
+    . "LEFT JOIN users creator ON creator.id = p.created_by "
+    . "LEFT JOIN users approver ON approver.id = p.approved_by "
+    . "WHERE p.id = ?";
+$stmtPkg = $pdo->prepare($sqlPackage);
+$stmtPkg->execute([$packageId]);
+$package = $stmtPkg->fetch();
+
+if (!$package) {
+    http_response_code(404);
+    echo 'Package not found.';
+    exit;
+}
+
+$sqlItems = "SELECT hpi.pass_to_hq, s.id AS submission_id, s.date, s.total_income, s.total_expenses, s.balance, "
+    . "o.name AS outlet_name, m.name AS manager_name "
+    . "FROM hq_package_items hpi "
+    . "INNER JOIN submissions s ON s.id = hpi.submission_id "
+    . "INNER JOIN outlets o ON o.id = s.outlet_id "
+    . "INNER JOIN users m ON m.id = s.manager_id "
+    . "WHERE hpi.package_id = ? "
+    . "ORDER BY o.name ASC, s.date ASC";
+$stmtItems = $pdo->prepare($sqlItems);
+$stmtItems->execute([$packageId]);
+$items = $stmtItems->fetchAll();
+
+$sqlReceipts = "SELECT r.submission_id, r.original_name, r.file_path "
+    . "FROM receipts r "
+    . "INNER JOIN hq_package_items hpi ON hpi.submission_id = r.submission_id "
+    . "WHERE hpi.package_id = ? "
+    . "ORDER BY r.original_name";
+$stmtReceipts = $pdo->prepare($sqlReceipts);
+$stmtReceipts->execute([$packageId]);
+$receipts = $stmtReceipts->fetchAll();
+
+$totals = [
+    'income' => 0.0,
+    'expenses' => 0.0,
+    'balance' => 0.0,
+    'pass_to_hq' => 0.0,
+];
+foreach ($items as $row) {
+    $totals['income'] += (float)($row['total_income'] ?? 0);
+    $totals['expenses'] += (float)($row['total_expenses'] ?? 0);
+    $totals['balance'] += (float)($row['balance'] ?? 0);
+    $totals['pass_to_hq'] += (float)($row['pass_to_hq'] ?? 0);
+}
+
+$spreadsheet = new Spreadsheet();
+$spreadsheet->removeSheetByIndex(0);
+
+$sheet1 = new Worksheet($spreadsheet, 'Package');
+$spreadsheet->addSheet($sheet1, 0);
+$sheet1->fromArray([
+    ['Package ID', $package['id']],
+    ['Package Date', $package['package_date'] ?? null],
+    ['Created By', $package['created_by_name'] ?? null],
+    ['Approved By', $package['approved_by_name'] ?? null],
+    ['Approved At', $package['approved_at'] ?? null],
+    ['Status', $package['status'] ?? null],
+    ['Total Income (RM)', $package['total_income'] ?? $totals['income']],
+    ['Total Expenses (RM)', $package['total_expenses'] ?? $totals['expenses']],
+    ['Total Balance (RM)', $package['total_balance'] ?? $totals['balance']],
+    ['Total Pass to HQ (RM)', $totals['pass_to_hq']],
+], null, 'A1');
+$sheet1->getColumnDimension('A')->setAutoSize(true);
+$sheet1->getColumnDimension('B')->setAutoSize(true);
+
+$sheet2 = new Worksheet($spreadsheet, 'Outlet Breakdown');
+$spreadsheet->addSheet($sheet2, 1);
+$sheet2->fromArray([
+    ['Outlet', 'Manager', 'Date', 'Income (RM)', 'Expenses (RM)', 'Balance (RM)', 'Pass to HQ (RM)'],
+], null, 'A1');
+$rowNum = 2;
+foreach ($items as $row) {
+    $sheet2->fromArray([
+        [
+            $row['outlet_name'] ?? null,
+            $row['manager_name'] ?? null,
+            $row['date'] ?? null,
+            $row['total_income'] ?? null,
+            $row['total_expenses'] ?? null,
+            $row['balance'] ?? null,
+            $row['pass_to_hq'] ?? null,
+        ],
+    ], null, 'A' . $rowNum);
+    $rowNum++;
+}
+$sheet2->fromArray([
+    ['Totals', null, null, $totals['income'], $totals['expenses'], $totals['balance'], $totals['pass_to_hq']],
+], null, 'A' . $rowNum);
+$sheet2->getStyle('A1:G1')->getFont()->setBold(true);
+$sheet2->getStyle('A' . $rowNum . ':G' . $rowNum)->getFont()->setBold(true);
+foreach (range('A', 'G') as $col) {
+    $sheet2->getColumnDimension($col)->setAutoSize(true);
+}
+
+if ($receipts) {
+    $sheet3 = new Worksheet($spreadsheet, 'Receipts');
+    $spreadsheet->addSheet($sheet3, 2);
+    $sheet3->fromArray([
+        ['Submission ID', 'Original Name', 'File Path'],
+    ], null, 'A1');
+    $rowNum = 2;
+    foreach ($receipts as $rec) {
+        $sheet3->fromArray([
+            [
+                $rec['submission_id'] ?? null,
+                $rec['original_name'] ?? null,
+                $rec['file_path'] ?? null,
+            ],
+        ], null, 'A' . $rowNum);
+        $rowNum++;
+    }
+    $sheet3->getStyle('A1:C1')->getFont()->setBold(true);
+    foreach (range('A', 'C') as $col) {
+        $sheet3->getColumnDimension($col)->setAutoSize(true);
+    }
+}
+
+$spreadsheet->setActiveSheetIndex(0);
+
+$filename = 'hq-package-' . $packageId . '.xlsx';
+header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+header('Content-Disposition: attachment; filename="' . $filename . '"');
+header('Cache-Control: max-age=0');
+
+$writer = new Xlsx($spreadsheet);
+$writer->save('php://output');
+exit;

--- a/account_hq_package_show.php
+++ b/account_hq_package_show.php
@@ -1,0 +1,195 @@
+<?php
+require __DIR__ . '/includes/auth.php';
+require_role(['account']);
+require __DIR__ . '/includes/db.php';
+
+$packageId = filter_input(INPUT_GET, 'package_id', FILTER_VALIDATE_INT);
+if (!$packageId) {
+    http_response_code(400);
+    echo 'Invalid package id.';
+    exit;
+}
+
+$sqlPackage = "SELECT p.*, "
+    . "creator.name AS created_by_name, "
+    . "approver.name AS approved_by_name "
+    . "FROM hq_packages p "
+    . "LEFT JOIN users creator ON creator.id = p.created_by "
+    . "LEFT JOIN users approver ON approver.id = p.approved_by "
+    . "WHERE p.id = ?";
+$stmtPkg = $pdo->prepare($sqlPackage);
+$stmtPkg->execute([$packageId]);
+$package = $stmtPkg->fetch();
+
+if (!$package) {
+    http_response_code(404);
+    echo 'Package not found.';
+    exit;
+}
+
+$sqlItems = "SELECT hpi.id, hpi.pass_to_hq, "
+    . "s.date, s.total_income, s.total_expenses, s.balance, "
+    . "o.name AS outlet_name, m.name AS manager_name "
+    . "FROM hq_package_items hpi "
+    . "INNER JOIN submissions s ON s.id = hpi.submission_id "
+    . "INNER JOIN outlets o ON o.id = s.outlet_id "
+    . "INNER JOIN users m ON m.id = s.manager_id "
+    . "WHERE hpi.package_id = ? "
+    . "ORDER BY o.name ASC, s.date ASC";
+$stmtItems = $pdo->prepare($sqlItems);
+$stmtItems->execute([$packageId]);
+$items = $stmtItems->fetchAll();
+
+$totals = [
+    'income' => 0.0,
+    'expenses' => 0.0,
+    'balance' => 0.0,
+    'pass_to_hq' => 0.0,
+];
+
+foreach ($items as $row) {
+    $totals['income'] += (float)($row['total_income'] ?? 0);
+    $totals['expenses'] += (float)($row['total_expenses'] ?? 0);
+    $totals['balance'] += (float)($row['balance'] ?? 0);
+    $totals['pass_to_hq'] += (float)($row['pass_to_hq'] ?? 0);
+}
+
+function format_money(?float $amount): string {
+    if ($amount === null) {
+        return '-';
+    }
+    return number_format((float)$amount, 2);
+}
+
+$packageDate = $package['package_date'] ?? $package['created_at'] ?? null;
+$packageDate = $packageDate ? date('Y-m-d', strtotime($packageDate)) : '—';
+$approvedAt = $package['approved_at'] ?? null;
+$approvedAt = $approvedAt ? date('Y-m-d H:i', strtotime($approvedAt)) : '—';
+$status = $package['status'] ?? 'pending';
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>HQ Package #<?= htmlspecialchars((string)$packageId) ?> — Account</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg bg-white border-bottom mb-4">
+  <div class="container">
+    <a class="navbar-brand" href="/daily_closing/views/account/queue.php">Daily Closing</a>
+    <div class="ms-auto d-flex gap-2">
+      <a class="btn btn-outline-secondary btn-sm" href="/daily_closing/views/account/queue.php">Back to Queue</a>
+      <a class="btn btn-outline-danger btn-sm" href="/daily_closing/logout.php">Logout</a>
+    </div>
+  </div>
+</nav>
+<main class="container pb-5">
+  <div class="d-flex flex-wrap align-items-start gap-3 mb-4">
+    <div>
+      <h1 class="h3 mb-1">HQ Package #<?= htmlspecialchars((string)$packageId) ?></h1>
+      <div class="text-muted small">Status: <?= htmlspecialchars(ucfirst((string)$status)) ?></div>
+    </div>
+    <div class="ms-auto d-flex flex-wrap gap-2">
+      <a class="btn btn-success" href="/daily_closing/account_hq_package_export.php?package_id=<?= urlencode((string)$packageId) ?>">
+        Export to Excel
+      </a>
+    </div>
+  </div>
+
+  <section class="card shadow-sm mb-4">
+    <div class="card-header bg-white">
+      <strong>Package Details</strong>
+    </div>
+    <div class="card-body row g-3">
+      <div class="col-md-3">
+        <div class="text-muted small">Package Date</div>
+        <div class="fw-semibold"><?= htmlspecialchars($packageDate) ?></div>
+      </div>
+      <div class="col-md-3">
+        <div class="text-muted small">Created By</div>
+        <div class="fw-semibold"><?= htmlspecialchars($package['created_by_name'] ?? '—') ?></div>
+      </div>
+      <div class="col-md-3">
+        <div class="text-muted small">Approved By</div>
+        <div class="fw-semibold"><?= htmlspecialchars($package['approved_by_name'] ?? '—') ?></div>
+      </div>
+      <div class="col-md-3">
+        <div class="text-muted small">Approved At</div>
+        <div class="fw-semibold"><?= htmlspecialchars($approvedAt) ?></div>
+      </div>
+      <div class="col-md-3">
+        <div class="text-muted small">Total Income (RM)</div>
+        <div class="fw-semibold"><?= format_money($package['total_income'] ?? $totals['income']) ?></div>
+      </div>
+      <div class="col-md-3">
+        <div class="text-muted small">Total Expenses (RM)</div>
+        <div class="fw-semibold"><?= format_money($package['total_expenses'] ?? $totals['expenses']) ?></div>
+      </div>
+      <div class="col-md-3">
+        <div class="text-muted small">Total Balance (RM)</div>
+        <div class="fw-semibold"><?= format_money($package['total_balance'] ?? $totals['balance']) ?></div>
+      </div>
+      <div class="col-md-3">
+        <div class="text-muted small">Total Pass to HQ (RM)</div>
+        <div class="fw-semibold"><?= format_money($totals['pass_to_hq']) ?></div>
+      </div>
+    </div>
+  </section>
+
+  <section class="card shadow-sm">
+    <div class="card-header bg-white">
+      <strong>Outlet Breakdown</strong>
+    </div>
+    <div class="card-body p-0">
+      <div class="table-responsive">
+        <table class="table table-striped table-hover mb-0 align-middle">
+          <thead class="table-light">
+            <tr>
+              <th>Outlet</th>
+              <th>Manager</th>
+              <th style="width:120px;">Date</th>
+              <th class="text-end" style="width:140px;">Income (RM)</th>
+              <th class="text-end" style="width:140px;">Expenses (RM)</th>
+              <th class="text-end" style="width:140px;">Balance (RM)</th>
+              <th class="text-end" style="width:150px;">Pass to HQ (RM)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php if (!$items): ?>
+              <tr>
+                <td colspan="7" class="text-center text-muted py-4">No submissions linked to this package.</td>
+              </tr>
+            <?php else: ?>
+              <?php foreach ($items as $row): ?>
+                <tr>
+                  <td><?= htmlspecialchars($row['outlet_name'] ?? '—') ?></td>
+                  <td><?= htmlspecialchars($row['manager_name'] ?? '—') ?></td>
+                  <td><?= htmlspecialchars($row['date'] ?? '') ?></td>
+                  <td class="text-end"><?= format_money($row['total_income'] ?? null) ?></td>
+                  <td class="text-end"><?= format_money($row['total_expenses'] ?? null) ?></td>
+                  <td class="text-end"><?= format_money($row['balance'] ?? null) ?></td>
+                  <td class="text-end"><?= format_money($row['pass_to_hq'] ?? null) ?></td>
+                </tr>
+              <?php endforeach; ?>
+            <?php endif; ?>
+          </tbody>
+          <?php if ($items): ?>
+          <tfoot class="table-light">
+            <tr>
+              <th colspan="3" class="text-end">Totals</th>
+              <th class="text-end"><?= format_money($totals['income']) ?></th>
+              <th class="text-end"><?= format_money($totals['expenses']) ?></th>
+              <th class="text-end"><?= format_money($totals['balance']) ?></th>
+              <th class="text-end"><?= format_money($totals['pass_to_hq']) ?></th>
+            </tr>
+          </tfoot>
+          <?php endif; ?>
+        </table>
+      </div>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/views/account/queue.php
+++ b/views/account/queue.php
@@ -1,4 +1,156 @@
 <?php
 require __DIR__ . '/../../includes/auth.php';
 require_role(['account']);
-?><!doctype html><meta charset="utf-8"><h2>Approval Queue</h2><a href="/daily_closing/logout.php">Logout</a>
+require __DIR__ . '/../../includes/db.php';
+
+$sql = "SELECT p.id, p.package_date, p.created_at, p.status, p.total_income, p.total_expenses, p.total_balance,
+               creator.name AS created_by_name,
+               approver.name AS approved_by_name,
+               COUNT(DISTINCT hpi.submission_id) AS submission_count,
+               COALESCE(SUM(s.total_income), 0) AS sum_income,
+               COALESCE(SUM(s.total_expenses), 0) AS sum_expenses,
+               COALESCE(SUM(s.balance), 0) AS sum_balance,
+               COALESCE(SUM(hpi.pass_to_hq), 0) AS sum_pass_to_hq,
+               MAX(s.date) AS last_submission_date
+        FROM hq_packages p
+        LEFT JOIN users creator ON creator.id = p.created_by
+        LEFT JOIN users approver ON approver.id = p.approved_by
+        LEFT JOIN hq_package_items hpi ON hpi.package_id = p.id
+        LEFT JOIN submissions s ON s.id = hpi.submission_id
+        GROUP BY p.id
+        ORDER BY COALESCE(p.package_date, p.created_at) DESC, p.id DESC";
+
+$packages = $pdo->query($sql)->fetchAll();
+
+function format_money($amount): string
+{
+    if ($amount === null || $amount === '') {
+        $amount = 0;
+    }
+    return 'RM ' . number_format((float) $amount, 2);
+}
+
+function format_date(?string $date, string $fallback = '—'): string
+{
+    if (!$date) {
+        return $fallback;
+    }
+    $ts = strtotime($date);
+    if (!$ts) {
+        return $fallback;
+    }
+    return date('Y-m-d', $ts);
+}
+
+function format_datetime(?string $date, string $fallback = '—'): string
+{
+    if (!$date) {
+        return $fallback;
+    }
+    $ts = strtotime($date);
+    if (!$ts) {
+        return $fallback;
+    }
+    return date('Y-m-d H:i', $ts);
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Account HQ Packages</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg bg-white border-bottom mb-4">
+  <div class="container">
+    <a class="navbar-brand" href="#">Daily Closing</a>
+    <div class="ms-auto">
+      <a class="btn btn-outline-danger btn-sm" href="/daily_closing/logout.php">Logout</a>
+    </div>
+  </div>
+</nav>
+<main class="container pb-5">
+  <div class="d-flex flex-wrap align-items-end gap-2 mb-3">
+    <div>
+      <h1 class="h3 mb-0">Approval Queue</h1>
+      <div class="text-muted small">Review HQ packages and export supporting data.</div>
+    </div>
+  </div>
+
+  <div class="card shadow-sm">
+    <div class="card-body p-0">
+      <div class="table-responsive">
+        <table class="table table-hover table-striped mb-0 align-middle">
+          <thead class="table-light">
+            <tr>
+              <th scope="col">Package</th>
+              <th scope="col">Package Date</th>
+              <th scope="col">Created By</th>
+              <th scope="col">Approved By</th>
+              <th scope="col">Submissions</th>
+              <th scope="col" class="text-end">Sales</th>
+              <th scope="col" class="text-end">Expenses</th>
+              <th scope="col" class="text-end">Balance</th>
+              <th scope="col" class="text-end">Pass to HQ</th>
+              <th scope="col">Status</th>
+              <th scope="col" class="text-end">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php if (!$packages): ?>
+              <tr>
+                <td colspan="11" class="text-center text-muted py-4">No packages have been submitted yet.</td>
+              </tr>
+            <?php else: ?>
+              <?php foreach ($packages as $pkg): ?>
+                <?php
+                  $status = $pkg['status'] ?? 'pending';
+                  $badgeClass = match ($status) {
+                      'approved' => 'bg-success',
+                      'rejected' => 'bg-danger',
+                      'processing' => 'bg-info text-dark',
+                      default => 'bg-secondary',
+                  };
+                  $totalIncome = $pkg['total_income'] ?? $pkg['sum_income'];
+                  $totalExpenses = $pkg['total_expenses'] ?? $pkg['sum_expenses'];
+                  $totalBalance = $pkg['total_balance'] ?? $pkg['sum_balance'];
+                ?>
+                <tr>
+                  <td>
+                    <div class="fw-semibold">#<?= htmlspecialchars((string) $pkg['id']) ?></div>
+                    <div class="small text-muted">Last submission: <?= htmlspecialchars($pkg['last_submission_date'] ? format_date($pkg['last_submission_date']) : '—') ?></div>
+                  </td>
+                  <td><?= htmlspecialchars(format_date($pkg['package_date'], format_date($pkg['created_at']))) ?></td>
+                  <td><?= htmlspecialchars($pkg['created_by_name'] ?? '—') ?></td>
+                  <td>
+                    <?php if ($pkg['approved_by_name']): ?>
+                      <div><?= htmlspecialchars($pkg['approved_by_name']) ?></div>
+                      <div class="small text-muted"><?= htmlspecialchars(format_datetime($pkg['approved_at'] ?? null)) ?></div>
+                    <?php else: ?>
+                      <span class="text-muted">—</span>
+                    <?php endif; ?>
+                  </td>
+                  <td><?= (int) $pkg['submission_count'] ?></td>
+                  <td class="text-end"><?= htmlspecialchars(format_money($totalIncome)) ?></td>
+                  <td class="text-end"><?= htmlspecialchars(format_money($totalExpenses)) ?></td>
+                  <td class="text-end"><?= htmlspecialchars(format_money($totalBalance)) ?></td>
+                  <td class="text-end"><?= htmlspecialchars(format_money($pkg['sum_pass_to_hq'])) ?></td>
+                  <td>
+                    <span class="badge <?= $badgeClass ?> text-uppercase"><?= htmlspecialchars($status) ?></span>
+                  </td>
+                  <td class="text-end">
+                    <a class="btn btn-primary btn-sm" href="/daily_closing/account_hq_package_show.php?package_id=<?= urlencode((string) $pkg['id']) ?>">Open</a>
+                  </td>
+                </tr>
+              <?php endforeach; ?>
+            <?php endif; ?>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an account-side package detail page with outlet-level breakdown and export action
- implement an Excel export using PhpSpreadsheet including optional receipts sheet

## Testing
- php -l account_hq_package_show.php
- php -l account_hq_package_export.php

------
https://chatgpt.com/codex/tasks/task_e_68dc8ec6f134832eac90f0c8f7d4b017