### PR TITLE
Add HQ package database schema migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Daily Closing
+
+## Database updates
+
+Database patch files are stored in `database/updates`. Account operators must run the SQL in each numbered file (e.g. `001_create_hq_package_tables.sql`) against the production database before deploying related application features.
+
+1. Review the assumptions block at the top of each script to confirm compatibility with your environment.
+2. Apply the SQL in sequence, starting with the lowest file number.
+3. Proceed with the application deployment only after all required patches have been executed successfully.
+
+Keeping the database schema in sync ensures the HQ package workflow (including package totals and item assignments) functions correctly in the UI.

--- a/database/updates/001_create_hq_package_tables.sql
+++ b/database/updates/001_create_hq_package_tables.sql
@@ -1,0 +1,56 @@
+/*
+Assumptions & Notes:
+- Target database is MySQL 8.0+ using InnoDB with utf8mb4_unicode_ci collation.
+- Existing `users` and `submissions` tables expose primary keys as BIGINT UNSIGNED `id` columns.
+- Status lifecycle for HQ packages is `draft`, `submitted`, `approved`, or `rejected`; default is `draft`.
+- Monetary totals are stored with DECIMAL(12,2) precision, reflecting PHP's rounding before persistence.
+- `pass_to_hq` is treated as a boolean flag (0 = no, 1 = yes).
+Please review and adjust data types, constraints, and enumerated values to match your production schema before executing.
+*/
+
+START TRANSACTION;
+
+CREATE TABLE IF NOT EXISTS `hq_packages` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `package_date` DATE NOT NULL,
+  `status` ENUM('draft','submitted','approved','rejected') NOT NULL DEFAULT 'draft',
+  `total_income` DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+  `total_expenses` DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+  `total_balance` DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+  `created_by` BIGINT UNSIGNED NOT NULL,
+  `approved_by` BIGINT UNSIGNED DEFAULT NULL,
+  `approved_at` DATETIME DEFAULT NULL,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_hq_packages_package_date` (`package_date`),
+  KEY `idx_hq_packages_status` (`status`),
+  KEY `idx_hq_packages_created_by` (`created_by`),
+  KEY `idx_hq_packages_approved_by` (`approved_by`),
+  CONSTRAINT `fk_hq_packages_created_by_users`
+    FOREIGN KEY (`created_by`) REFERENCES `users`(`id`)
+    ON UPDATE CASCADE,
+  CONSTRAINT `fk_hq_packages_approved_by_users`
+    FOREIGN KEY (`approved_by`) REFERENCES `users`(`id`)
+    ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `hq_package_items` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `package_id` BIGINT UNSIGNED NOT NULL,
+  `submission_id` BIGINT UNSIGNED NOT NULL,
+  `pass_to_hq` TINYINT(1) NOT NULL DEFAULT 0,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_hq_package_items_package_submission` (`package_id`, `submission_id`),
+  KEY `idx_hq_package_items_submission_id` (`submission_id`),
+  CONSTRAINT `fk_hq_package_items_package`
+    FOREIGN KEY (`package_id`) REFERENCES `hq_packages`(`id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  CONSTRAINT `fk_hq_package_items_submission`
+    FOREIGN KEY (`submission_id`) REFERENCES `submissions`(`id`)
+    ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a numbered SQL patch to create the `hq_packages` and `hq_package_items` tables with keys and foreign keys
- document database update workflow and reference the new `database/updates` directory in the project README

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc9552a924832e9ef3eca10ee2f8de