### PR TITLE
Fix account queue to show submitted HQ batches

### DIFF
--- a/account_hq_package_export.php
+++ b/account_hq_package_export.php
@@ -15,110 +15,129 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
-$packageId = filter_input(INPUT_GET, 'package_id', FILTER_VALIDATE_INT);
-if (!$packageId) {
+$batchId = filter_input(INPUT_GET, 'batch_id', FILTER_VALIDATE_INT);
+if (!$batchId) {
+    // Backwards compatibility with previous query string.
+    $batchId = filter_input(INPUT_GET, 'package_id', FILTER_VALIDATE_INT);
+}
+
+if (!$batchId) {
     http_response_code(400);
-    echo 'Invalid package id.';
+    echo 'Invalid batch id.';
     exit;
 }
 
-$sqlPackage = "SELECT p.*, "
-    . "creator.name AS created_by_name, "
-    . "approver.name AS approved_by_name "
-    . "FROM hq_packages p "
-    . "LEFT JOIN users creator ON creator.id = p.created_by "
-    . "LEFT JOIN users approver ON approver.id = p.approved_by "
-    . "WHERE p.id = ?";
-$stmtPkg = $pdo->prepare($sqlPackage);
-$stmtPkg->execute([$packageId]);
-$package = $stmtPkg->fetch();
+$sqlBatch = "SELECT b.*, m.name AS manager_name, m.email AS manager_email "
+    . "FROM hq_batches b "
+    . "INNER JOIN users m ON m.id = b.manager_id "
+    . "WHERE b.id = ?";
+$stmtBatch = $pdo->prepare($sqlBatch);
+$stmtBatch->execute([$batchId]);
+$batch = $stmtBatch->fetch();
 
-if (!$package) {
+if (!$batch) {
     http_response_code(404);
-    echo 'Package not found.';
+    echo 'HQ batch not found.';
     exit;
 }
 
-$sqlItems = "SELECT hpi.pass_to_hq, s.id AS submission_id, s.date, s.total_income, s.total_expenses, s.balance, "
-    . "o.name AS outlet_name, m.name AS manager_name "
-    . "FROM hq_package_items hpi "
-    . "INNER JOIN submissions s ON s.id = hpi.submission_id "
+$sqlItems = "SELECT s.id AS submission_id, s.date, s.total_income, s.total_expenses, s.balance, s.status, s.submitted_to_hq_at, "
+    . "o.name AS outlet_name, mgr.name AS submission_manager "
+    . "FROM hq_batch_submissions hbs "
+    . "INNER JOIN submissions s ON s.id = hbs.submission_id "
     . "INNER JOIN outlets o ON o.id = s.outlet_id "
-    . "INNER JOIN users m ON m.id = s.manager_id "
-    . "WHERE hpi.package_id = ? "
-    . "ORDER BY o.name ASC, s.date ASC";
+    . "INNER JOIN users mgr ON mgr.id = s.manager_id "
+    . "WHERE hbs.hq_batch_id = ? "
+    . "ORDER BY o.name ASC, s.date ASC, s.id ASC";
 $stmtItems = $pdo->prepare($sqlItems);
-$stmtItems->execute([$packageId]);
-$items = $stmtItems->fetchAll();
+$stmtItems->execute([$batchId]);
+$items = $stmtItems->fetchAll() ?: [];
 
 $sqlReceipts = "SELECT r.submission_id, r.original_name, r.file_path "
     . "FROM receipts r "
-    . "INNER JOIN hq_package_items hpi ON hpi.submission_id = r.submission_id "
-    . "WHERE hpi.package_id = ? "
+    . "INNER JOIN hq_batch_submissions hbs ON hbs.submission_id = r.submission_id "
+    . "WHERE hbs.hq_batch_id = ? "
     . "ORDER BY r.original_name";
 $stmtReceipts = $pdo->prepare($sqlReceipts);
-$stmtReceipts->execute([$packageId]);
-$receipts = $stmtReceipts->fetchAll();
+$stmtReceipts->execute([$batchId]);
+$receipts = $stmtReceipts->fetchAll() ?: [];
+
+$sqlAttachments = "SELECT original_name, file_path, size_bytes, created_at "
+    . "FROM hq_batch_files WHERE hq_batch_id = ? ORDER BY original_name";
+$stmtAttachments = $pdo->prepare($sqlAttachments);
+$stmtAttachments->execute([$batchId]);
+$attachments = $stmtAttachments->fetchAll() ?: [];
 
 $totals = [
     'income' => 0.0,
     'expenses' => 0.0,
     'balance' => 0.0,
-    'pass_to_hq' => 0.0,
 ];
 foreach ($items as $row) {
     $totals['income'] += (float)($row['total_income'] ?? 0);
     $totals['expenses'] += (float)($row['total_expenses'] ?? 0);
     $totals['balance'] += (float)($row['balance'] ?? 0);
-    $totals['pass_to_hq'] += (float)($row['pass_to_hq'] ?? 0);
 }
+
+$submittedAt = null;
+foreach ($items as $row) {
+    $ts = !empty($row['submitted_to_hq_at']) ? strtotime($row['submitted_to_hq_at']) : null;
+    if ($ts && ($submittedAt === null || $ts > $submittedAt)) {
+        $submittedAt = $ts;
+    }
+}
+$submittedAtStr = $submittedAt ? date('Y-m-d H:i', $submittedAt) : null;
 
 $spreadsheet = new Spreadsheet();
 $spreadsheet->removeSheetByIndex(0);
 
-$sheet1 = new Worksheet($spreadsheet, 'Package');
+$sheet1 = new Worksheet($spreadsheet, 'Batch');
 $spreadsheet->addSheet($sheet1, 0);
 $sheet1->fromArray([
-    ['Package ID', $package['id']],
-    ['Package Date', $package['package_date'] ?? null],
-    ['Created By', $package['created_by_name'] ?? null],
-    ['Approved By', $package['approved_by_name'] ?? null],
-    ['Approved At', $package['approved_at'] ?? null],
-    ['Status', $package['status'] ?? null],
-    ['Total Income (RM)', $package['total_income'] ?? $totals['income']],
-    ['Total Expenses (RM)', $package['total_expenses'] ?? $totals['expenses']],
-    ['Total Balance (RM)', $package['total_balance'] ?? $totals['balance']],
-    ['Total Pass to HQ (RM)', $totals['pass_to_hq']],
+    ['Batch ID', $batch['id']],
+    ['Business Date', $batch['report_date'] ?? null],
+    ['Manager', $batch['manager_name'] ?? null],
+    ['Manager Email', $batch['manager_email'] ?? null],
+    ['Status', $batch['status'] ?? null],
+    ['Submitted At', $submittedAtStr],
+    ['Created At', $batch['created_at'] ?? null],
+    ['Updated At', $batch['updated_at'] ?? null],
+    ['Notes', $batch['notes'] ?? null],
+    ['Total Income (RM)', $batch['overall_total_income'] ?? $totals['income']],
+    ['Total Expenses (RM)', $batch['overall_total_expenses'] ?? $totals['expenses']],
+    ['Total Balance (RM)', $batch['overall_balance'] ?? $totals['balance']],
 ], null, 'A1');
 $sheet1->getColumnDimension('A')->setAutoSize(true);
 $sheet1->getColumnDimension('B')->setAutoSize(true);
 
-$sheet2 = new Worksheet($spreadsheet, 'Outlet Breakdown');
+$sheet2 = new Worksheet($spreadsheet, 'Submissions');
 $spreadsheet->addSheet($sheet2, 1);
 $sheet2->fromArray([
-    ['Outlet', 'Manager', 'Date', 'Income (RM)', 'Expenses (RM)', 'Balance (RM)', 'Pass to HQ (RM)'],
+    ['Submission ID', 'Date', 'Outlet', 'Manager', 'Income (RM)', 'Expenses (RM)', 'Balance (RM)', 'Status', 'Submitted At'],
 ], null, 'A1');
 $rowNum = 2;
 foreach ($items as $row) {
     $sheet2->fromArray([
         [
-            $row['outlet_name'] ?? null,
-            $row['manager_name'] ?? null,
+            $row['submission_id'] ?? null,
             $row['date'] ?? null,
+            $row['outlet_name'] ?? null,
+            $row['submission_manager'] ?? null,
             $row['total_income'] ?? null,
             $row['total_expenses'] ?? null,
             $row['balance'] ?? null,
-            $row['pass_to_hq'] ?? null,
+            $row['status'] ?? null,
+            !empty($row['submitted_to_hq_at']) ? date('Y-m-d H:i', strtotime($row['submitted_to_hq_at'])) : null,
         ],
     ], null, 'A' . $rowNum);
     $rowNum++;
 }
 $sheet2->fromArray([
-    ['Totals', null, null, $totals['income'], $totals['expenses'], $totals['balance'], $totals['pass_to_hq']],
+    ['Totals', null, null, null, $totals['income'], $totals['expenses'], $totals['balance'], null, null],
 ], null, 'A' . $rowNum);
-$sheet2->getStyle('A1:G1')->getFont()->setBold(true);
-$sheet2->getStyle('A' . $rowNum . ':G' . $rowNum)->getFont()->setBold(true);
-foreach (range('A', 'G') as $col) {
+$sheet2->getStyle('A1:I1')->getFont()->setBold(true);
+$sheet2->getStyle('A' . $rowNum . ':I' . $rowNum)->getFont()->setBold(true);
+foreach (range('A', 'I') as $col) {
     $sheet2->getColumnDimension($col)->setAutoSize(true);
 }
 
@@ -145,9 +164,33 @@ if ($receipts) {
     }
 }
 
+if ($attachments) {
+    $sheet = new Worksheet($spreadsheet, 'HQ Attachments');
+    $spreadsheet->addSheet($sheet, $spreadsheet->getSheetCount());
+    $sheet->fromArray([
+        ['Original Name', 'File Path', 'Size (bytes)', 'Uploaded At'],
+    ], null, 'A1');
+    $rowNum = 2;
+    foreach ($attachments as $file) {
+        $sheet->fromArray([
+            [
+                $file['original_name'] ?? null,
+                $file['file_path'] ?? null,
+                $file['size_bytes'] ?? null,
+                $file['created_at'] ?? null,
+            ],
+        ], null, 'A' . $rowNum);
+        $rowNum++;
+    }
+    $sheet->getStyle('A1:D1')->getFont()->setBold(true);
+    foreach (range('A', 'D') as $col) {
+        $sheet->getColumnDimension($col)->setAutoSize(true);
+    }
+}
+
 $spreadsheet->setActiveSheetIndex(0);
 
-$filename = 'hq-package-' . $packageId . '.xlsx';
+$filename = 'hq-batch-' . $batchId . '.xlsx';
 header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
 header('Content-Disposition: attachment; filename="' . $filename . '"');
 header('Cache-Control: max-age=0');

--- a/account_hq_package_show.php
+++ b/account_hq_package_show.php
@@ -3,76 +3,119 @@ require __DIR__ . '/includes/auth.php';
 require_role(['account']);
 require __DIR__ . '/includes/db.php';
 
-$packageId = filter_input(INPUT_GET, 'package_id', FILTER_VALIDATE_INT);
-if (!$packageId) {
+$batchId = filter_input(INPUT_GET, 'batch_id', FILTER_VALIDATE_INT);
+if (!$batchId) {
+    // Backwards compatibility with the old query string.
+    $batchId = filter_input(INPUT_GET, 'package_id', FILTER_VALIDATE_INT);
+}
+
+if (!$batchId) {
     http_response_code(400);
-    echo 'Invalid package id.';
+    echo 'Invalid batch id.';
     exit;
 }
 
-$sqlPackage = "SELECT p.*, "
-    . "creator.name AS created_by_name, "
-    . "approver.name AS approved_by_name "
-    . "FROM hq_packages p "
-    . "LEFT JOIN users creator ON creator.id = p.created_by "
-    . "LEFT JOIN users approver ON approver.id = p.approved_by "
-    . "WHERE p.id = ?";
-$stmtPkg = $pdo->prepare($sqlPackage);
-$stmtPkg->execute([$packageId]);
-$package = $stmtPkg->fetch();
+$sqlBatch = "SELECT b.*, m.name AS manager_name, m.email AS manager_email "
+    . "FROM hq_batches b "
+    . "INNER JOIN users m ON m.id = b.manager_id "
+    . "WHERE b.id = ?";
+$stmtBatch = $pdo->prepare($sqlBatch);
+$stmtBatch->execute([$batchId]);
+$batch = $stmtBatch->fetch();
 
-if (!$package) {
+if (!$batch) {
     http_response_code(404);
-    echo 'Package not found.';
+    echo 'HQ batch not found.';
     exit;
 }
 
-$sqlItems = "SELECT hpi.id, hpi.pass_to_hq, "
-    . "s.date, s.total_income, s.total_expenses, s.balance, "
-    . "o.name AS outlet_name, m.name AS manager_name "
-    . "FROM hq_package_items hpi "
-    . "INNER JOIN submissions s ON s.id = hpi.submission_id "
+$sqlItems = "SELECT s.id AS submission_id, s.date, s.total_income, s.total_expenses, s.balance, s.status, s.submitted_to_hq_at, "
+    . "o.name AS outlet_name, mgr.name AS submission_manager "
+    . "FROM hq_batch_submissions hbs "
+    . "INNER JOIN submissions s ON s.id = hbs.submission_id "
     . "INNER JOIN outlets o ON o.id = s.outlet_id "
-    . "INNER JOIN users m ON m.id = s.manager_id "
-    . "WHERE hpi.package_id = ? "
-    . "ORDER BY o.name ASC, s.date ASC";
+    . "INNER JOIN users mgr ON mgr.id = s.manager_id "
+    . "WHERE hbs.hq_batch_id = ? "
+    . "ORDER BY o.name ASC, s.date ASC, s.id ASC";
 $stmtItems = $pdo->prepare($sqlItems);
-$stmtItems->execute([$packageId]);
-$items = $stmtItems->fetchAll();
+$stmtItems->execute([$batchId]);
+$items = $stmtItems->fetchAll() ?: [];
+
+$sqlFiles = "SELECT id, file_path, original_name, mime, size_bytes, created_at "
+    . "FROM hq_batch_files WHERE hq_batch_id = ? ORDER BY original_name";
+$stmtFiles = $pdo->prepare($sqlFiles);
+$stmtFiles->execute([$batchId]);
+$attachments = $stmtFiles->fetchAll() ?: [];
 
 $totals = [
     'income' => 0.0,
     'expenses' => 0.0,
     'balance' => 0.0,
-    'pass_to_hq' => 0.0,
 ];
+$submittedAt = null;
+$outletTotals = [];
 
 foreach ($items as $row) {
     $totals['income'] += (float)($row['total_income'] ?? 0);
     $totals['expenses'] += (float)($row['total_expenses'] ?? 0);
     $totals['balance'] += (float)($row['balance'] ?? 0);
-    $totals['pass_to_hq'] += (float)($row['pass_to_hq'] ?? 0);
+
+    $ts = !empty($row['submitted_to_hq_at']) ? strtotime($row['submitted_to_hq_at']) : null;
+    if ($ts && ($submittedAt === null || $ts > $submittedAt)) {
+        $submittedAt = $ts;
+    }
+
+    $outlet = $row['outlet_name'] ?? '—';
+    if (!isset($outletTotals[$outlet])) {
+        $outletTotals[$outlet] = [
+            'income' => 0.0,
+            'expenses' => 0.0,
+            'balance' => 0.0,
+        ];
+    }
+    $outletTotals[$outlet]['income'] += (float)($row['total_income'] ?? 0);
+    $outletTotals[$outlet]['expenses'] += (float)($row['total_expenses'] ?? 0);
+    $outletTotals[$outlet]['balance'] += (float)($row['balance'] ?? 0);
 }
 
-function format_money(?float $amount): string {
+if ($outletTotals) {
+    ksort($outletTotals, SORT_NATURAL | SORT_FLAG_CASE);
+}
+
+function format_money(?float $amount): string
+{
     if ($amount === null) {
         return '-';
     }
-    return number_format((float)$amount, 2);
+
+    return number_format((float) $amount, 2);
 }
 
-$packageDate = $package['package_date'] ?? $package['created_at'] ?? null;
-$packageDate = $packageDate ? date('Y-m-d', strtotime($packageDate)) : '—';
-$approvedAt = $package['approved_at'] ?? null;
-$approvedAt = $approvedAt ? date('Y-m-d H:i', strtotime($approvedAt)) : '—';
-$status = $package['status'] ?? 'pending';
+$submittedAtStr = $submittedAt ? date('Y-m-d H:i', $submittedAt) : '—';
+$status = $batch['status'] ?? 'submitted';
+function format_size(?float $bytes): string
+{
+    if ($bytes === null) {
+        return '—';
+    }
+
+    if ($bytes >= 1048576) {
+        return number_format($bytes / 1048576, 2) . ' MB';
+    }
+
+    if ($bytes >= 1024) {
+        return number_format($bytes / 1024, 1) . ' KB';
+    }
+
+    return number_format($bytes, 0) . ' B';
+}
 ?>
 <!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>HQ Package #<?= htmlspecialchars((string)$packageId) ?> — Account</title>
+  <title>HQ Batch #<?= htmlspecialchars((string) $batchId) ?> — Account</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body class="bg-light">
@@ -88,11 +131,11 @@ $status = $package['status'] ?? 'pending';
 <main class="container pb-5">
   <div class="d-flex flex-wrap align-items-start gap-3 mb-4">
     <div>
-      <h1 class="h3 mb-1">HQ Package #<?= htmlspecialchars((string)$packageId) ?></h1>
-      <div class="text-muted small">Status: <?= htmlspecialchars(ucfirst((string)$status)) ?></div>
+      <h1 class="h3 mb-1">HQ Batch #<?= htmlspecialchars((string) $batchId) ?></h1>
+      <div class="text-muted small">Status: <?= htmlspecialchars(ucfirst((string) $status)) ?></div>
     </div>
     <div class="ms-auto d-flex flex-wrap gap-2">
-      <a class="btn btn-success" href="/daily_closing/account_hq_package_export.php?package_id=<?= urlencode((string)$packageId) ?>">
+      <a class="btn btn-success" href="/daily_closing/account_hq_package_export.php?batch_id=<?= urlencode((string) $batchId) ?>">
         Export to Excel
       </a>
     </div>
@@ -100,94 +143,165 @@ $status = $package['status'] ?? 'pending';
 
   <section class="card shadow-sm mb-4">
     <div class="card-header bg-white">
-      <strong>Package Details</strong>
+      <strong>Batch Overview</strong>
     </div>
     <div class="card-body row g-3">
       <div class="col-md-3">
-        <div class="text-muted small">Package Date</div>
-        <div class="fw-semibold"><?= htmlspecialchars($packageDate) ?></div>
+        <div class="text-muted small text-uppercase">Business Date</div>
+        <div class="fw-semibold"><?= htmlspecialchars($batch['report_date'] ?? '—') ?></div>
       </div>
       <div class="col-md-3">
-        <div class="text-muted small">Created By</div>
-        <div class="fw-semibold"><?= htmlspecialchars($package['created_by_name'] ?? '—') ?></div>
+        <div class="text-muted small text-uppercase">Manager</div>
+        <div class="fw-semibold"><?= htmlspecialchars($batch['manager_name'] ?? '—') ?></div>
+        <?php if (!empty($batch['manager_email'])): ?>
+          <div class="text-muted small"><?= htmlspecialchars($batch['manager_email']) ?></div>
+        <?php endif; ?>
       </div>
       <div class="col-md-3">
-        <div class="text-muted small">Approved By</div>
-        <div class="fw-semibold"><?= htmlspecialchars($package['approved_by_name'] ?? '—') ?></div>
+        <div class="text-muted small text-uppercase">Submitted At</div>
+        <div class="fw-semibold"><?= htmlspecialchars($submittedAtStr) ?></div>
       </div>
       <div class="col-md-3">
-        <div class="text-muted small">Approved At</div>
-        <div class="fw-semibold"><?= htmlspecialchars($approvedAt) ?></div>
+        <div class="text-muted small text-uppercase">Last Updated</div>
+        <div class="fw-semibold"><?= htmlspecialchars($batch['updated_at'] ?? '—') ?></div>
       </div>
-      <div class="col-md-3">
-        <div class="text-muted small">Total Income (RM)</div>
-        <div class="fw-semibold"><?= format_money($package['total_income'] ?? $totals['income']) ?></div>
+      <div class="col-md-4">
+        <div class="text-muted small text-uppercase">Total Income (RM)</div>
+        <div class="fw-semibold fs-5"><?= format_money($batch['overall_total_income'] ?? $totals['income']) ?></div>
       </div>
-      <div class="col-md-3">
-        <div class="text-muted small">Total Expenses (RM)</div>
-        <div class="fw-semibold"><?= format_money($package['total_expenses'] ?? $totals['expenses']) ?></div>
+      <div class="col-md-4">
+        <div class="text-muted small text-uppercase">Total Expenses (RM)</div>
+        <div class="fw-semibold fs-5"><?= format_money($batch['overall_total_expenses'] ?? $totals['expenses']) ?></div>
       </div>
-      <div class="col-md-3">
-        <div class="text-muted small">Total Balance (RM)</div>
-        <div class="fw-semibold"><?= format_money($package['total_balance'] ?? $totals['balance']) ?></div>
+      <div class="col-md-4">
+        <div class="text-muted small text-uppercase">Total Balance (RM)</div>
+        <div class="fw-semibold fs-5"><?= format_money($batch['overall_balance'] ?? $totals['balance']) ?></div>
       </div>
-      <div class="col-md-3">
-        <div class="text-muted small">Total Pass to HQ (RM)</div>
-        <div class="fw-semibold"><?= format_money($totals['pass_to_hq']) ?></div>
-      </div>
+      <?php if (!empty($batch['notes'])): ?>
+        <div class="col-12">
+          <div class="text-muted small text-uppercase">Notes</div>
+          <div><?= nl2br(htmlspecialchars($batch['notes'])) ?></div>
+        </div>
+      <?php endif; ?>
     </div>
   </section>
 
-  <section class="card shadow-sm">
+  <section class="card shadow-sm mb-4">
     <div class="card-header bg-white">
-      <strong>Outlet Breakdown</strong>
+      <strong>Per-Outlet Summary</strong>
+    </div>
+    <div class="card-body p-0">
+      <?php if (!$outletTotals): ?>
+        <div class="p-4 text-muted text-center">No outlet breakdown available.</div>
+      <?php else: ?>
+        <div class="table-responsive">
+          <table class="table table-striped table-hover mb-0 align-middle">
+            <thead class="table-light">
+              <tr>
+                <th>Outlet</th>
+                <th class="text-end" style="width:140px;">Income (RM)</th>
+                <th class="text-end" style="width:150px;">Expenses (RM)</th>
+                <th class="text-end" style="width:150px;">Balance (RM)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php foreach ($outletTotals as $outlet => $values): ?>
+                <tr>
+                  <td><?= htmlspecialchars($outlet) ?></td>
+                  <td class="text-end"><?= format_money($values['income']) ?></td>
+                  <td class="text-end"><?= format_money($values['expenses']) ?></td>
+                  <td class="text-end"><?= format_money($values['balance']) ?></td>
+                </tr>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+      <?php endif; ?>
+    </div>
+  </section>
+
+  <section class="card shadow-sm mb-4">
+    <div class="card-header bg-white">
+      <strong>Included Submissions</strong>
     </div>
     <div class="card-body p-0">
       <div class="table-responsive">
         <table class="table table-striped table-hover mb-0 align-middle">
           <thead class="table-light">
             <tr>
+              <th style="width:110px;">Submission</th>
+              <th style="width:120px;">Date</th>
               <th>Outlet</th>
               <th>Manager</th>
-              <th style="width:120px;">Date</th>
               <th class="text-end" style="width:140px;">Income (RM)</th>
-              <th class="text-end" style="width:140px;">Expenses (RM)</th>
+              <th class="text-end" style="width:150px;">Expenses (RM)</th>
               <th class="text-end" style="width:140px;">Balance (RM)</th>
-              <th class="text-end" style="width:150px;">Pass to HQ (RM)</th>
+              <th>Status</th>
+              <th style="width:120px;">Submitted At</th>
+              <th class="text-end" style="width:110px;">Actions</th>
             </tr>
           </thead>
           <tbody>
             <?php if (!$items): ?>
               <tr>
-                <td colspan="7" class="text-center text-muted py-4">No submissions linked to this package.</td>
+                <td colspan="10" class="text-center text-muted py-4">No submissions were linked to this batch.</td>
               </tr>
             <?php else: ?>
               <?php foreach ($items as $row): ?>
+                <?php
+                  $badge = match ($row['status']) {
+                      'pending'  => 'warning',
+                      'approved' => 'success',
+                      'rejected' => 'danger',
+                      'recorded' => 'secondary',
+                      default    => 'light',
+                  };
+                  $rowSubmitted = !empty($row['submitted_to_hq_at']) ? date('Y-m-d H:i', strtotime($row['submitted_to_hq_at'])) : '—';
+                ?>
                 <tr>
-                  <td><?= htmlspecialchars($row['outlet_name'] ?? '—') ?></td>
-                  <td><?= htmlspecialchars($row['manager_name'] ?? '—') ?></td>
+                  <td>#<?= (int) $row['submission_id'] ?></td>
                   <td><?= htmlspecialchars($row['date'] ?? '') ?></td>
+                  <td><?= htmlspecialchars($row['outlet_name'] ?? '—') ?></td>
+                  <td><?= htmlspecialchars($row['submission_manager'] ?? '—') ?></td>
                   <td class="text-end"><?= format_money($row['total_income'] ?? null) ?></td>
                   <td class="text-end"><?= format_money($row['total_expenses'] ?? null) ?></td>
                   <td class="text-end"><?= format_money($row['balance'] ?? null) ?></td>
-                  <td class="text-end"><?= format_money($row['pass_to_hq'] ?? null) ?></td>
+                  <td><span class="badge text-bg-<?= $badge ?>"><?= htmlspecialchars(ucfirst((string) $row['status'])) ?></span></td>
+                  <td><?= htmlspecialchars($rowSubmitted) ?></td>
+                  <td class="text-end">
+                    <a class="btn btn-sm btn-outline-secondary" href="/daily_closing/manager_submission_view.php?id=<?= urlencode((string) $row['submission_id']) ?>" target="_blank">View</a>
+                  </td>
                 </tr>
               <?php endforeach; ?>
             <?php endif; ?>
           </tbody>
-          <?php if ($items): ?>
-          <tfoot class="table-light">
-            <tr>
-              <th colspan="3" class="text-end">Totals</th>
-              <th class="text-end"><?= format_money($totals['income']) ?></th>
-              <th class="text-end"><?= format_money($totals['expenses']) ?></th>
-              <th class="text-end"><?= format_money($totals['balance']) ?></th>
-              <th class="text-end"><?= format_money($totals['pass_to_hq']) ?></th>
-            </tr>
-          </tfoot>
-          <?php endif; ?>
         </table>
       </div>
+    </div>
+  </section>
+
+  <section class="card shadow-sm">
+    <div class="card-header bg-white">
+      <strong>HQ Attachments</strong>
+    </div>
+    <div class="card-body">
+      <?php if (!$attachments): ?>
+        <p class="text-muted mb-0">No attachments uploaded for this batch.</p>
+      <?php else: ?>
+        <div class="list-group list-group-flush">
+          <?php foreach ($attachments as $file): ?>
+            <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" href="/daily_closing<?= htmlspecialchars($file['file_path']) ?>" target="_blank">
+              <span>
+                <?= htmlspecialchars($file['original_name'] ?? basename((string) $file['file_path'])) ?>
+                <?php if (!empty($file['created_at'])): ?>
+                  <small class="text-muted d-block">Uploaded: <?= htmlspecialchars($file['created_at']) ?></small>
+                <?php endif; ?>
+              </span>
+              <span class="text-muted small ms-3"><?= format_size($file['size_bytes'] ?? null) ?></span>
+            </a>
+          <?php endforeach; ?>
+        </div>
+      <?php endif; ?>
     </div>
   </section>
 </main>

--- a/views/account/queue.php
+++ b/views/account/queue.php
@@ -3,24 +3,28 @@ require __DIR__ . '/../../includes/auth.php';
 require_role(['account']);
 require __DIR__ . '/../../includes/db.php';
 
-$sql = "SELECT p.id, p.package_date, p.created_at, p.status, p.total_income, p.total_expenses, p.total_balance,
-               creator.name AS created_by_name,
-               approver.name AS approved_by_name,
-               COUNT(DISTINCT hpi.submission_id) AS submission_count,
-               COALESCE(SUM(s.total_income), 0) AS sum_income,
-               COALESCE(SUM(s.total_expenses), 0) AS sum_expenses,
-               COALESCE(SUM(s.balance), 0) AS sum_balance,
-               COALESCE(SUM(hpi.pass_to_hq), 0) AS sum_pass_to_hq,
-               MAX(s.date) AS last_submission_date
-        FROM hq_packages p
-        LEFT JOIN users creator ON creator.id = p.created_by
-        LEFT JOIN users approver ON approver.id = p.approved_by
-        LEFT JOIN hq_package_items hpi ON hpi.package_id = p.id
-        LEFT JOIN submissions s ON s.id = hpi.submission_id
-        GROUP BY p.id
-        ORDER BY COALESCE(p.package_date, p.created_at) DESC, p.id DESC";
+$sql = "SELECT b.id,
+               b.report_date,
+               b.status,
+               b.overall_total_income,
+               b.overall_total_expenses,
+               b.overall_balance,
+               b.created_at,
+               b.updated_at,
+               m.name AS manager_name,
+               COUNT(DISTINCT hbs.submission_id) AS submission_count,
+               COUNT(DISTINCT s.outlet_id)     AS outlet_count,
+               MAX(s.submitted_to_hq_at)       AS submitted_at,
+               MAX(s.date)                     AS last_submission_date
+        FROM hq_batches b
+        INNER JOIN users m ON m.id = b.manager_id
+        LEFT JOIN hq_batch_submissions hbs ON hbs.hq_batch_id = b.id
+        LEFT JOIN submissions s ON s.id = hbs.submission_id
+        WHERE b.status IN ('submitted', 'processing')
+        GROUP BY b.id
+        ORDER BY b.report_date DESC, b.id DESC";
 
-$packages = $pdo->query($sql)->fetchAll();
+$batches = $pdo->query($sql)->fetchAll();
 
 function format_money($amount): string
 {
@@ -85,63 +89,56 @@ function format_datetime(?string $date, string $fallback = '—'): string
         <table class="table table-hover table-striped mb-0 align-middle">
           <thead class="table-light">
             <tr>
-              <th scope="col">Package</th>
-              <th scope="col">Package Date</th>
-              <th scope="col">Created By</th>
-              <th scope="col">Approved By</th>
-              <th scope="col">Submissions</th>
-              <th scope="col" class="text-end">Sales</th>
-              <th scope="col" class="text-end">Expenses</th>
-              <th scope="col" class="text-end">Balance</th>
-              <th scope="col" class="text-end">Pass to HQ</th>
+              <th scope="col">Batch</th>
+              <th scope="col">Business Date</th>
+              <th scope="col">Manager</th>
+              <th scope="col" class="text-center">Outlets</th>
+              <th scope="col" class="text-center">Submissions</th>
+              <th scope="col" class="text-end">Income (RM)</th>
+              <th scope="col" class="text-end">Expenses (RM)</th>
+              <th scope="col" class="text-end">Balance (RM)</th>
+              <th scope="col">Submitted At</th>
               <th scope="col">Status</th>
               <th scope="col" class="text-end">Actions</th>
             </tr>
           </thead>
           <tbody>
-            <?php if (!$packages): ?>
+            <?php if (!$batches): ?>
               <tr>
-                <td colspan="11" class="text-center text-muted py-4">No packages have been submitted yet.</td>
+                <td colspan="11" class="text-center text-muted py-4">No HQ submissions are waiting for review.</td>
               </tr>
             <?php else: ?>
-              <?php foreach ($packages as $pkg): ?>
+              <?php foreach ($batches as $batch): ?>
                 <?php
-                  $status = $pkg['status'] ?? 'pending';
+                  $status = $batch['status'] ?? 'submitted';
                   $badgeClass = match ($status) {
-                      'approved' => 'bg-success',
-                      'rejected' => 'bg-danger',
+                      'submitted'  => 'bg-warning text-dark',
                       'processing' => 'bg-info text-dark',
-                      default => 'bg-secondary',
+                      'approved'   => 'bg-success',
+                      'recorded'   => 'bg-primary',
+                      'rejected'   => 'bg-danger',
+                      default      => 'bg-secondary',
                   };
-                  $totalIncome = $pkg['total_income'] ?? $pkg['sum_income'];
-                  $totalExpenses = $pkg['total_expenses'] ?? $pkg['sum_expenses'];
-                  $totalBalance = $pkg['total_balance'] ?? $pkg['sum_balance'];
+                  $submittedAt = $batch['submitted_at'] ? format_datetime($batch['submitted_at']) : '—';
                 ?>
                 <tr>
                   <td>
-                    <div class="fw-semibold">#<?= htmlspecialchars((string) $pkg['id']) ?></div>
-                    <div class="small text-muted">Last submission: <?= htmlspecialchars($pkg['last_submission_date'] ? format_date($pkg['last_submission_date']) : '—') ?></div>
+                    <div class="fw-semibold">#<?= htmlspecialchars((string) $batch['id']) ?></div>
+                    <div class="small text-muted">Last submission: <?= htmlspecialchars($batch['last_submission_date'] ? format_date($batch['last_submission_date']) : '—') ?></div>
                   </td>
-                  <td><?= htmlspecialchars(format_date($pkg['package_date'], format_date($pkg['created_at']))) ?></td>
-                  <td><?= htmlspecialchars($pkg['created_by_name'] ?? '—') ?></td>
-                  <td>
-                    <?php if ($pkg['approved_by_name']): ?>
-                      <div><?= htmlspecialchars($pkg['approved_by_name']) ?></div>
-                      <div class="small text-muted"><?= htmlspecialchars(format_datetime($pkg['approved_at'] ?? null)) ?></div>
-                    <?php else: ?>
-                      <span class="text-muted">—</span>
-                    <?php endif; ?>
-                  </td>
-                  <td><?= (int) $pkg['submission_count'] ?></td>
-                  <td class="text-end"><?= htmlspecialchars(format_money($totalIncome)) ?></td>
-                  <td class="text-end"><?= htmlspecialchars(format_money($totalExpenses)) ?></td>
-                  <td class="text-end"><?= htmlspecialchars(format_money($totalBalance)) ?></td>
-                  <td class="text-end"><?= htmlspecialchars(format_money($pkg['sum_pass_to_hq'])) ?></td>
+                  <td><?= htmlspecialchars(format_date($batch['report_date'], '—')) ?></td>
+                  <td><?= htmlspecialchars($batch['manager_name'] ?? '—') ?></td>
+                  <td class="text-center"><?= (int) $batch['outlet_count'] ?></td>
+                  <td class="text-center"><?= (int) $batch['submission_count'] ?></td>
+                  <td class="text-end"><?= htmlspecialchars(format_money($batch['overall_total_income'])) ?></td>
+                  <td class="text-end"><?= htmlspecialchars(format_money($batch['overall_total_expenses'])) ?></td>
+                  <td class="text-end"><?= htmlspecialchars(format_money($batch['overall_balance'])) ?></td>
+                  <td><?= htmlspecialchars($submittedAt) ?></td>
                   <td>
                     <span class="badge <?= $badgeClass ?> text-uppercase"><?= htmlspecialchars($status) ?></span>
                   </td>
                   <td class="text-end">
-                    <a class="btn btn-primary btn-sm" href="/daily_closing/account_hq_package_show.php?package_id=<?= urlencode((string) $pkg['id']) ?>">Open</a>
+                    <a class="btn btn-primary btn-sm" href="/daily_closing/account_hq_package_show.php?batch_id=<?= urlencode((string) $batch['id']) ?>">Open</a>
                   </td>
                 </tr>
               <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- update the account approval queue to list submitted HQ batches and surface manager, outlet, and submission totals
- replace the account batch detail page with an HQ batch view that includes submission breakdowns and attachments
- refresh the Excel export to pull data from HQ batches, submissions, and attachments

## Testing
- php -l views/account/queue.php
- php -l account_hq_package_show.php
- php -l account_hq_package_export.php

------
https://chatgpt.com/codex/tasks/task_e_68dce552fbac832ea26aa99229b2b28b