### PR TITLE
Implement Pass to Office workflow and redesign manager dashboard

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -85,6 +85,7 @@ CREATE TABLE `hq_batches` (
   `status` enum('submitted','approved','rejected','recorded') NOT NULL DEFAULT 'submitted',
   `overall_total_income` decimal(14,2) NOT NULL DEFAULT 0.00,
   `overall_total_expenses` decimal(14,2) NOT NULL DEFAULT 0.00,
+  `overall_pass_to_office` decimal(14,2) NOT NULL DEFAULT 0.00,
   `overall_balance` decimal(14,2) NOT NULL DEFAULT 0.00,
   `notes` text DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
@@ -101,7 +102,7 @@ CREATE TABLE `hq_batches` (
 
 LOCK TABLES `hq_batches` WRITE;
 /*!40000 ALTER TABLE `hq_batches` DISABLE KEYS */;
-INSERT INTO `hq_batches` VALUES (1,1,'2025-10-01','submitted',11000.00,1010.00,9990.00,'','2025-10-01 02:31:07','2025-10-01 02:31:07');
+INSERT INTO `hq_batches` VALUES (1,1,'2025-10-01','submitted',11000.00,1010.00,0.00,9990.00,'','2025-10-01 02:31:07','2025-10-01 02:31:07');
 /*!40000 ALTER TABLE `hq_batches` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -318,6 +319,7 @@ CREATE TABLE `submissions` (
   `total_income` decimal(12,2) NOT NULL DEFAULT 0.00,
   `total_expenses` decimal(12,2) NOT NULL DEFAULT 0.00,
   `balance` decimal(12,2) NOT NULL DEFAULT 0.00,
+  `pass_to_office` decimal(12,2) NOT NULL DEFAULT 0.00,
   `notes` text DEFAULT NULL,
   `account_comment` text DEFAULT NULL,
   `submitted_to_hq_at` datetime DEFAULT NULL,
@@ -339,7 +341,7 @@ CREATE TABLE `submissions` (
 
 LOCK TABLES `submissions` WRITE;
 /*!40000 ALTER TABLE `submissions` DISABLE KEYS */;
-INSERT INTO `submissions` VALUES (2,1,2,'2025-10-01','pending',1000.00,10.00,990.00,'testing',NULL,'2025-10-01 10:31:07','2025-10-01 01:00:02','2025-10-01 02:31:07'),(3,1,1,'2025-10-01','pending',1270.00,200.00,1070.00,'',NULL,NULL,'2025-10-01 14:09:44','2025-10-01 14:09:44');
+INSERT INTO `submissions` VALUES (2,1,2,'2025-10-01','pending',1000.00,10.00,990.00,0.00,'testing',NULL,'2025-10-01 10:31:07','2025-10-01 01:00:02','2025-10-01 02:31:07'),(3,1,1,'2025-10-01','pending',1270.00,200.00,1070.00,0.00,'',NULL,NULL,'2025-10-01 14:09:44','2025-10-01 14:09:44');
 /*!40000 ALTER TABLE `submissions` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/includes/cash_metrics.php
+++ b/includes/cash_metrics.php
@@ -1,0 +1,103 @@
+<?php
+// /daily_closing/includes/cash_metrics.php
+
+use PDO;
+
+/**
+ * Calculate cash on hand metrics for a manager scoped to optional outlets and date range.
+ *
+ * @param PDO   $pdo
+ * @param int   $managerId
+ * @param array $outletIds Optional array of outlet IDs to constrain the calculation.
+ * @param array $options   Supported keys:
+ *                         - 'date_from' (Y-m-d) inclusive lower bound
+ *                         - 'date_to'   (Y-m-d) inclusive upper bound
+ *                         - 'statuses'  array of submission statuses to include
+ * @return array{pending: float, posted: float, income: float, expenses: float, pass_to_office: float}
+ */
+function manager_cash_on_hand(PDO $pdo, int $managerId, array $outletIds = [], array $options = []): array
+{
+    $where = ['s.manager_id = :manager_id'];
+    $params = ['manager_id' => $managerId];
+
+    if ($outletIds) {
+        $in = [];
+        foreach ($outletIds as $index => $outletId) {
+            $placeholder = ':outlet_' . $index;
+            $params[$placeholder] = (int)$outletId;
+            $in[] = $placeholder;
+        }
+        $where[] = 's.outlet_id IN (' . implode(',', $in) . ')';
+    }
+
+    if (!empty($options['date_from'])) {
+        $where[] = 's.date >= :date_from';
+        $params['date_from'] = $options['date_from'];
+    }
+
+    if (!empty($options['date_to'])) {
+        $where[] = 's.date <= :date_to';
+        $params['date_to'] = $options['date_to'];
+    }
+
+    if (!empty($options['statuses']) && is_array($options['statuses'])) {
+        $statuses = [];
+        foreach ($options['statuses'] as $index => $status) {
+            $status = (string)$status;
+            if ($status === '') {
+                continue;
+            }
+            $placeholder = ':status_' . $index;
+            $params[$placeholder] = $status;
+            $statuses[] = $placeholder;
+        }
+        if ($statuses) {
+            $where[] = 's.status IN (' . implode(',', $statuses) . ')';
+        }
+    }
+
+    $sql = '
+        SELECT
+            SUM(CASE WHEN s.status IN (\'approved\', \'recorded\') THEN (s.total_income - s.total_expenses - s.pass_to_office) ELSE 0 END) AS posted_delta,
+            SUM(CASE WHEN s.status IN (\'pending\', \'submitted\', \'draft\') THEN (s.total_income - s.total_expenses - s.pass_to_office) ELSE 0 END) AS pending_delta,
+            SUM(s.total_income) AS income_total,
+            SUM(s.total_expenses) AS expenses_total,
+            SUM(s.pass_to_office) AS pass_total
+        FROM submissions s
+        WHERE ' . implode(' AND ', $where) . '
+    ';
+
+    $stmt = $pdo->prepare($sql);
+    foreach ($params as $key => $value) {
+        $type = is_int($value) ? PDO::PARAM_INT : PDO::PARAM_STR;
+        $stmt->bindValue($key, $value, $type);
+    }
+    $stmt->execute();
+
+    $row = $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
+
+    return [
+        'pending' => (float)($row['pending_delta'] ?? 0.0),
+        'posted' => (float)($row['posted_delta'] ?? 0.0),
+        'income' => (float)($row['income_total'] ?? 0.0),
+        'expenses' => (float)($row['expenses_total'] ?? 0.0),
+        'pass_to_office' => (float)($row['pass_total'] ?? 0.0),
+    ];
+}
+
+/**
+ * Convenience helper for validation — returns the posted cash on hand for a specific outlet.
+ */
+function outlet_posted_cash_on_hand(PDO $pdo, int $managerId, int $outletId): float
+{
+    $sql = '
+        SELECT COALESCE(SUM(s.total_income - s.total_expenses - s.pass_to_office), 0)
+        FROM submissions s
+        WHERE s.manager_id = ? AND s.outlet_id = ? AND s.status IN (\'approved\', \'recorded\')
+    ';
+
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([$managerId, $outletId]);
+
+    return (float)$stmt->fetchColumn();
+}

--- a/manager_hq_batch_view.php
+++ b/manager_hq_batch_view.php
@@ -13,7 +13,7 @@ if ($batchId <= 0) {
 }
 
 $sql = "
-    SELECT b.id, b.report_date, b.status, b.overall_total_income, b.overall_total_expenses, b.overall_balance, b.notes
+    SELECT b.id, b.report_date, b.status, b.overall_total_income, b.overall_total_expenses, b.overall_pass_to_office, b.overall_balance, b.notes
     FROM hq_batches b
     WHERE b.id = ? AND b.manager_id = ?
 ";
@@ -27,7 +27,7 @@ if (!$batch) {
 }
 
 $stmtSub = $pdo->prepare("\
-    SELECT s.id, s.date, s.total_income, s.total_expenses, s.balance, s.status, s.submitted_to_hq_at,\
+    SELECT s.id, s.date, s.total_income, s.total_expenses, s.balance, s.pass_to_office, s.status, s.submitted_to_hq_at,\
            o.name AS outlet_name\
     FROM hq_batch_submissions hbs\
     JOIN submissions s ON s.id = hbs.submission_id\
@@ -52,12 +52,14 @@ foreach ($submissions as $row) {
         $outletTotals[$outlet] = [
             'income'   => 0.0,
             'expenses' => 0.0,
+            'pass'     => 0.0,
             'balance'  => 0.0,
             'submissions' => [],
         ];
     }
     $outletTotals[$outlet]['income']   += (float)$row['total_income'];
     $outletTotals[$outlet]['expenses'] += (float)$row['total_expenses'];
+    $outletTotals[$outlet]['pass']     += (float)$row['pass_to_office'];
     $outletTotals[$outlet]['balance']  += (float)$row['balance'];
     $outletTotals[$outlet]['submissions'][] = $row;
 }

--- a/manager_hq_batches.php
+++ b/manager_hq_batches.php
@@ -27,6 +27,7 @@ $sql = "
         b.status,
         b.overall_total_income,
         b.overall_total_expenses,
+        b.overall_pass_to_office,
         b.overall_balance,
         b.notes,
         COUNT(DISTINCT s.outlet_id)   AS outlet_count,

--- a/manager_submissions.php
+++ b/manager_submissions.php
@@ -51,7 +51,9 @@ $pages = max(1, (int)ceil($total / $pp));
 
 // --- list ---
 $sql = "
-  SELECT s.id, s.date, s.status, s.total_income, s.total_expenses, s.balance, o.name AS outlet
+  SELECT s.id, s.date, s.status, s.total_income, s.total_expenses, s.balance, s.pass_to_office,
+         (s.total_income - s.total_expenses - s.pass_to_office) AS net_cash,
+         o.name AS outlet
   FROM submissions s
   JOIN outlets o ON o.id = s.outlet_id
   $WHERE

--- a/views/manager/dashboard.php
+++ b/views/manager/dashboard.php
@@ -1,54 +1,20 @@
 <?php
 require __DIR__ . '/../../includes/auth_guard.php';
 require __DIR__ . '/../../includes/db.php';
+require __DIR__ . '/../../includes/cash_metrics.php';
 
 guard_manager();
 
 $managerId = current_manager_id();
 $outlets = allowed_outlets($pdo);
-
-$sessionKey = 'manager_dashboard_filters_' . $managerId;
-$allowedTabs = ['submissions', 'hq', 'remittances'];
-$defaultFilters = [
-    'submissions'  => ['range' => 'week', 'status' => 'all', 'outlets' => [], 'date_from' => '', 'date_to' => ''],
-    'hq'           => ['range' => 'week', 'status' => 'all', 'outlets' => [], 'date_from' => '', 'date_to' => ''],
-    'remittances'  => ['range' => 'week', 'status' => 'all', 'outlets' => [], 'date_from' => '', 'date_to' => ''],
-];
-
-if (!isset($_SESSION[$sessionKey])) {
-    $_SESSION[$sessionKey] = $defaultFilters + ['tab' => 'submissions'];
+$outletIds = array_map(static fn(array $row) => (int)$row['id'], $outlets);
+$outletLookup = [];
+foreach ($outlets as $row) {
+    $outletLookup[(int)$row['id']] = $row['name'];
 }
-
-$tab = $_GET['tab'] ?? ($_SESSION[$sessionKey]['tab'] ?? 'submissions');
-if (!in_array($tab, $allowedTabs, true)) {
-    $tab = 'submissions';
-}
-$_SESSION[$sessionKey]['tab'] = $tab;
-
-$action = $_GET['action'] ?? '';
-
-$availableOutletIds = array_map(static fn(array $row) => (int)$row['id'], $outlets);
-$availableOutletIds = array_values(array_unique($availableOutletIds));
-
-$redirectToTab = static function (string $tab) {
-    $query = http_build_query(['tab' => $tab]);
-    header('Location: /daily_closing/views/manager/dashboard.php?' . $query);
-    exit;
-};
-
-$sanitizeOutlets = static function (array $raw, array $allowed): array {
-    $selected = [];
-    foreach ($raw as $value) {
-        $id = (int)$value;
-        if (in_array($id, $allowed, true)) {
-            $selected[] = $id;
-        }
-    }
-    return array_values(array_unique($selected));
-};
 
 $parseDate = static function (?string $value): ?string {
-    if (!$value) {
+    if ($value === null) {
         return null;
     }
     $value = trim($value);
@@ -59,353 +25,195 @@ $parseDate = static function (?string $value): ?string {
     return $dt ? $dt->format('Y-m-d') : null;
 };
 
-$computeRange = static function (string $range, ?string $from, ?string $to): array {
-    $today = new DateTimeImmutable('today');
-    $end = $today;
-    $start = $today;
+$today = new DateTimeImmutable('today');
+$defaultFrom = $today->modify('-6 days')->format('Y-m-d');
+$defaultTo = $today->format('Y-m-d');
 
-    switch ($range) {
-        case 'today':
-            break;
-        case 'month':
-            $start = $today->modify('first day of this month');
-            break;
-        case 'custom':
-            if ($from && $to) {
-                $startDt = DateTimeImmutable::createFromFormat('Y-m-d', $from);
-                $endDt = DateTimeImmutable::createFromFormat('Y-m-d', $to);
-                if ($startDt && $endDt && $startDt <= $endDt) {
-                    $start = $startDt;
-                    $end = $endDt;
-                    break;
-                }
-            }
-            // fall through to default week if invalid custom
-        default:
-            $range = 'week';
-            $start = $today->modify('monday this week');
-            break;
-    }
-
-    if ($range === 'week') {
-        $start = $today->modify('monday this week');
-    }
-
-    return [$start->format('Y-m-d'), $end->format('Y-m-d'), $range];
-};
-
-if ($action === 'reset' && isset($_GET['tab']) && in_array($_GET['tab'], $allowedTabs, true)) {
-    $_SESSION[$sessionKey][$_GET['tab']] = $defaultFilters[$_GET['tab']];
-    $redirectToTab($_GET['tab']);
-}
-
-if ($action === 'apply' && isset($_GET['tab']) && in_array($_GET['tab'], $allowedTabs, true)) {
-    $range = $_GET['range'] ?? 'week';
-    $status = $_GET['status'] ?? 'all';
-    $rawOutlets = $_GET['outlets'] ?? [];
-    if (!is_array($rawOutlets)) {
-        $rawOutlets = [$rawOutlets];
-    }
-    $selectedOutlets = $sanitizeOutlets($rawOutlets, $availableOutletIds);
-    $dateFrom = $parseDate($_GET['date_from'] ?? '');
-    $dateTo = $parseDate($_GET['date_to'] ?? '');
-
-    $_SESSION[$sessionKey][$_GET['tab']] = [
-        'range' => in_array($range, ['today', 'week', 'month', 'custom'], true) ? $range : 'week',
-        'status' => $status ?: 'all',
-        'outlets' => $selectedOutlets,
-        'date_from' => $dateFrom ?? '',
-        'date_to' => $dateTo ?? '',
-    ];
-
-    $redirectToTab($_GET['tab']);
-}
-
-$currentFilters = $_SESSION[$sessionKey][$tab] ?? $defaultFilters[$tab];
-[$dateStart, $dateEnd, $normalizedRange] = $computeRange(
-    $currentFilters['range'] ?? 'week',
-    $currentFilters['date_from'] ?: null,
-    $currentFilters['date_to'] ?: null
-);
-$currentFilters['range'] = $normalizedRange;
-$dateStartParam = $dateStart;
-$dateEndParam = $dateEnd;
-
-$selectedOutletIds = $currentFilters['outlets'];
-if (!$selectedOutletIds) {
-    $selectedOutletIds = $availableOutletIds;
-}
-
-$outletLookup = [];
-foreach ($outlets as $outlet) {
-    $outletLookup[(int)$outlet['id']] = $outlet['name'];
-}
-
-$selectedOutletNames = [];
-foreach ($selectedOutletIds as $outletId) {
-    if (isset($outletLookup[$outletId])) {
-        $selectedOutletNames[] = $outletLookup[$outletId];
-    }
-}
-
-$selectedOutletSummary = 'All outlets';
-if ($selectedOutletNames && count($selectedOutletIds) !== count($availableOutletIds)) {
-    if (count($selectedOutletNames) <= 2) {
-        $selectedOutletSummary = implode(', ', $selectedOutletNames);
-    } else {
-        $selectedOutletSummary = count($selectedOutletNames) . ' outlets selected';
-    }
-}
-
-$buildPlaceholders = static function (array $ids): string {
-    return implode(',', array_fill(0, count($ids), '?'));
-};
-
-$metrics = [
-    'sales_approved' => 0.0,
-    'expenses_approved' => 0.0,
-    'cash_on_hand' => 0.0,
-    'last_remittance' => null,
-];
-
-if ($availableOutletIds) {
-    $today = (new DateTimeImmutable('today'))->format('Y-m-d');
-
-    $placeholders = $buildPlaceholders($availableOutletIds);
-
-    $sqlApproved = "SELECT IFNULL(SUM(total_income),0) AS total_income, IFNULL(SUM(total_expenses),0) AS total_expenses FROM submissions WHERE status = 'approved' AND manager_id = ? AND outlet_id IN ($placeholders)";
-    $stmt = $pdo->prepare($sqlApproved);
-    $stmt->execute(array_merge([$managerId], $availableOutletIds));
-    $row = $stmt->fetch(PDO::FETCH_ASSOC) ?: ['total_income' => 0, 'total_expenses' => 0];
-    $metrics['sales_approved'] = (float)$row['total_income'];
-    $metrics['expenses_approved'] = (float)$row['total_expenses'];
-    $approvedNet = max(0.0, $metrics['sales_approved'] - $metrics['expenses_approved']);
-
-    $sqlRemit = "SELECT IFNULL(SUM(amount),0) FROM hq_remittances WHERE status = 'approved' AND outlet_id IN ($placeholders)";
-    $stmt = $pdo->prepare($sqlRemit);
-    $stmt->execute($availableOutletIds);
-    $approvedRemit = (float)$stmt->fetchColumn();
-
-    $metrics['cash_on_hand'] = max(0, $approvedNet - $approvedRemit);
-
-    $sqlLast = "SELECT received_at, amount, status FROM hq_remittances WHERE outlet_id IN ($placeholders) ORDER BY received_at DESC, id DESC LIMIT 1";
-    $stmt = $pdo->prepare($sqlLast);
-    $stmt->execute($availableOutletIds);
-    $metrics['last_remittance'] = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
-}
-
-$submissions = [];
-$hqBatches = [];
-$remittances = [];
-
-if ($availableOutletIds) {
-    $placeholdersSelected = $buildPlaceholders($selectedOutletIds);
-
-    if ($tab === 'submissions') {
-        $params = [$managerId, $dateStartParam, $dateEndParam];
-        $where = "WHERE s.manager_id = ? AND s.date BETWEEN ? AND ?";
-        if ($selectedOutletIds && count($selectedOutletIds) !== count($availableOutletIds)) {
-            $where .= " AND s.outlet_id IN ($placeholdersSelected)";
-            $params = array_merge($params, $selectedOutletIds);
+$selectedOutletIds = [];
+if (!empty($_GET['outlets']) && is_array($_GET['outlets'])) {
+    foreach ($_GET['outlets'] as $value) {
+        $id = (int)$value;
+        if (in_array($id, $outletIds, true)) {
+            $selectedOutletIds[] = $id;
         }
-        $status = $currentFilters['status'] ?? 'all';
-        if ($status !== 'all') {
-            $where .= ' AND s.status = ?';
-            $params[] = $status;
-        }
-
-        $sql = "
-            SELECT
-                s.id,
-                s.date,
-                s.status,
-                s.total_income,
-                s.total_expenses,
-                s.total_income - s.total_expenses AS balance,
-                o.name AS outlet_name,
-                COUNT(i.id) AS item_count
-            FROM submissions s
-            JOIN outlets o ON o.id = s.outlet_id
-            LEFT JOIN submission_items i ON i.submission_id = s.id
-            $where
-            GROUP BY s.id, s.date, s.status, s.total_income, s.total_expenses, o.name
-            ORDER BY s.date DESC, s.id DESC
-            LIMIT 20
-        ";
-
-        $stmt = $pdo->prepare($sql);
-        $stmt->execute($params);
-        $submissions = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
     }
+    $selectedOutletIds = array_values(array_unique($selectedOutletIds));
+}
+if (!$selectedOutletIds && $outletIds) {
+    $selectedOutletIds = $outletIds;
+}
 
-    if ($tab === 'hq') {
-        $params = [$managerId, $dateStartParam, $dateEndParam];
-        $where = "WHERE b.manager_id = ? AND b.report_date BETWEEN ? AND ?";
-        $extraParams = [];
-        if ($selectedOutletIds && count($selectedOutletIds) !== count($availableOutletIds)) {
-            $place = $buildPlaceholders($selectedOutletIds);
-            $where .= " AND EXISTS (
-                SELECT 1 FROM hq_batch_submissions bs
-                JOIN submissions s2 ON s2.id = bs.submission_id
-                WHERE bs.hq_batch_id = b.id AND s2.outlet_id IN ($place)
-            )";
-            $extraParams = array_merge($extraParams, $selectedOutletIds);
-        }
-        $status = $currentFilters['status'] ?? 'all';
-        if ($status !== 'all') {
-            $where .= ' AND b.status = ?';
-            $extraParams[] = $status;
-        }
-
-        $sql = "
-            SELECT
-                b.id,
-                b.report_date,
-                b.status,
-                b.overall_total_income,
-                b.overall_total_expenses,
-                b.overall_balance,
-                COALESCE(COUNT(DISTINCT s.outlet_id), 0) AS outlet_count,
-                COALESCE(COUNT(bs.submission_id), 0) AS submission_count
-            FROM hq_batches b
-            LEFT JOIN hq_batch_submissions bs ON bs.hq_batch_id = b.id
-            LEFT JOIN submissions s ON s.id = bs.submission_id
-            $where
-            GROUP BY b.id, b.report_date, b.status, b.overall_total_income, b.overall_total_expenses, b.overall_balance
-            ORDER BY b.report_date DESC, b.id DESC
-            LIMIT 20
-        ";
-
-        $stmt = $pdo->prepare($sql);
-        $stmt->execute(array_merge($params, $extraParams));
-        $hqBatches = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
-    }
-
-    if ($tab === 'remittances') {
-        $where = [];
-        $params = [];
-        $placeAll = $buildPlaceholders($availableOutletIds);
-        $where[] = "r.outlet_id IN ($placeAll)";
-        $params = array_merge($params, $availableOutletIds);
-        $where[] = 'r.received_at BETWEEN ? AND ?';
-        $params[] = $dateStartParam;
-        $params[] = $dateEndParam;
-        if ($selectedOutletIds && count($selectedOutletIds) !== count($availableOutletIds)) {
-            $where[] = "r.outlet_id IN ($placeholdersSelected)";
-            $params = array_merge($params, $selectedOutletIds);
-        }
-        $status = $currentFilters['status'] ?? 'all';
-        if ($status !== 'all') {
-            $where[] = 'r.status = ?';
-            $params[] = $status;
-        }
-
-        $sql = "
-            SELECT
-                r.id,
-                r.outlet_id,
-                r.submission_id,
-                r.amount,
-                r.received_at,
-                r.status,
-                r.bank_ref,
-                o.name AS outlet_name
-            FROM hq_remittances r
-            JOIN outlets o ON o.id = r.outlet_id
-            WHERE " . implode(' AND ', $where) . "
-            ORDER BY r.received_at DESC, r.id DESC
-            LIMIT 20
-        ";
-
-        $stmt = $pdo->prepare($sql);
-        $stmt->execute($params);
-        $remittances = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
-    }
+$dateFrom = $parseDate($_GET['date_from'] ?? '') ?? $defaultFrom;
+$dateTo = $parseDate($_GET['date_to'] ?? '') ?? $defaultTo;
+if ($dateFrom > $dateTo) {
+    [$dateFrom, $dateTo] = [$dateTo, $dateFrom];
 }
 
 $statusOptions = [
-    'submissions' => [
-        'all' => 'All statuses',
-        'submitted' => 'Submitted',
-        'approved' => 'Approved',
-        'rejected' => 'Rejected',
-        'recorded' => 'Recorded',
-    ],
-    'hq' => [
-        'all' => 'All statuses',
-        'submitted' => 'Submitted',
-        'processing' => 'Processing',
-        'acknowledged' => 'Acknowledged',
-        'rejected' => 'Rejected',
-        'completed' => 'Completed',
-    ],
-    'remittances' => [
-        'all' => 'All statuses',
-        'pending' => 'Pending',
-        'approved' => 'Approved',
-        'declined' => 'Declined',
-    ],
+    'all' => ['label' => 'All statuses', 'statuses' => []],
+    'draft' => ['label' => 'Draft', 'statuses' => ['draft']],
+    'submitted' => ['label' => 'Submitted', 'statuses' => ['pending']],
+    'approved' => ['label' => 'Approved', 'statuses' => ['approved']],
+    'rejected' => ['label' => 'Rejected', 'statuses' => ['rejected']],
+    'posted' => ['label' => 'Posted', 'statuses' => ['recorded']],
 ];
+$selectedStatus = $_GET['status'] ?? 'all';
+if (!isset($statusOptions[$selectedStatus])) {
+    $selectedStatus = 'all';
+}
+$statusFilter = $statusOptions[$selectedStatus]['statuses'];
 
-$rangeOptions = [
-    'today' => 'Today',
-    'week' => 'This week',
-    'month' => 'This month',
-    'custom' => 'Custom range',
-];
+$selectedOutletSummary = 'All outlets';
+if ($selectedOutletIds && count($selectedOutletIds) !== count($outletIds)) {
+    $names = [];
+    foreach ($selectedOutletIds as $id) {
+        if (isset($outletLookup[$id])) {
+            $names[] = $outletLookup[$id];
+        }
+    }
+    if ($names) {
+        $selectedOutletSummary = count($names) <= 2 ? implode(', ', $names) : (count($names) . ' outlets selected');
+    }
+}
+
+$where = ['s.manager_id = ?'];
+$params = [$managerId];
+
+$where[] = 's.date BETWEEN ? AND ?';
+$params[] = $dateFrom;
+$params[] = $dateTo;
+
+if ($selectedOutletIds && count($selectedOutletIds) !== count($outletIds)) {
+    $placeholders = implode(',', array_fill(0, count($selectedOutletIds), '?'));
+    $where[] = "s.outlet_id IN ($placeholders)";
+    $params = array_merge($params, $selectedOutletIds);
+}
+
+if ($statusFilter) {
+    $placeholders = implode(',', array_fill(0, count($statusFilter), '?'));
+    $where[] = "s.status IN ($placeholders)";
+    $params = array_merge($params, $statusFilter);
+}
+
+$whereClause = implode(' AND ', $where);
+
+$activitySql = "
+    SELECT
+        s.id,
+        s.date,
+        s.status,
+        s.total_income,
+        s.total_expenses,
+        s.pass_to_office,
+        s.balance,
+        s.updated_at,
+        s.submitted_to_hq_at,
+        o.name AS outlet_name,
+        COUNT(DISTINCT r.id) AS receipts_count
+    FROM submissions s
+    JOIN outlets o ON o.id = s.outlet_id
+    LEFT JOIN receipts r ON r.submission_id = s.id
+    WHERE $whereClause
+    GROUP BY s.id, s.date, s.status, s.total_income, s.total_expenses, s.pass_to_office, s.balance, s.updated_at, s.submitted_to_hq_at, o.name
+    ORDER BY s.date DESC, s.id DESC
+    LIMIT 25
+";
+$stmt = $pdo->prepare($activitySql);
+$stmt->execute($params);
+$activityRows = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+$countSql = "SELECT s.status, COUNT(*) AS total FROM submissions s WHERE $whereClause GROUP BY s.status";
+$stmt = $pdo->prepare($countSql);
+$stmt->execute($params);
+$statusCounts = [];
+foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+    $statusCounts[$row['status']] = (int)$row['total'];
+}
+
+$missingReceipts = 0;
+foreach ($activityRows as $row) {
+    if ((int)$row['receipts_count'] === 0 && in_array($row['status'], ['pending', 'approved'], true)) {
+        $missingReceipts++;
+    }
+}
+
+$cohOverall = manager_cash_on_hand($pdo, $managerId, $selectedOutletIds);
+$rangeMetrics = manager_cash_on_hand($pdo, $managerId, $selectedOutletIds, [
+    'date_from' => $dateFrom,
+    'date_to' => $dateTo,
+]);
+$postedRange = manager_cash_on_hand($pdo, $managerId, $selectedOutletIds, [
+    'date_from' => $dateFrom,
+    'date_to' => $dateTo,
+    'statuses' => ['approved', 'recorded'],
+]);
+$todayMetrics = manager_cash_on_hand($pdo, $managerId, $selectedOutletIds, [
+    'date_from' => $today->format('Y-m-d'),
+    'date_to' => $today->format('Y-m-d'),
+]);
+$yesterdayMetrics = manager_cash_on_hand($pdo, $managerId, $selectedOutletIds, [
+    'date_from' => $today->modify('-1 day')->format('Y-m-d'),
+    'date_to' => $today->modify('-1 day')->format('Y-m-d'),
+]);
 
 function format_money(float $value): string
 {
     return number_format($value, 2);
 }
 
-function status_badge_class(string $status): string
+function status_chip_class(string $status): string
 {
     return match ($status) {
-        'submitted', 'pending' => 'warning',
-        'approved', 'completed', 'acknowledged' => 'success',
-        'rejected', 'declined' => 'danger',
-        'processing' => 'info',
-        'recorded' => 'secondary',
+        'draft' => 'secondary',
+        'pending' => 'info',
+        'approved' => 'success',
+        'recorded' => 'primary',
+        'rejected' => 'danger',
         default => 'secondary',
     };
+}
+
+function status_display_label(string $status): string
+{
+    return match ($status) {
+        'pending' => 'Submitted',
+        'recorded' => 'Posted',
+        default => ucfirst($status),
+    };
+}
+
+$flashOk = $_SESSION['flash_ok'] ?? null;
+$flashError = $_SESSION['flash_error'] ?? null;
+unset($_SESSION['flash_ok'], $_SESSION['flash_error']);
+
+$appliedFilters = [];
+if ($selectedOutletIds && count($selectedOutletIds) !== count($outletIds)) {
+    $appliedFilters[] = $selectedOutletSummary;
+}
+if ($dateFrom !== $defaultFrom || $dateTo !== $defaultTo) {
+    $appliedFilters[] = $dateFrom . ' → ' . $dateTo;
+}
+if ($selectedStatus !== 'all') {
+    $appliedFilters[] = $statusOptions[$selectedStatus]['label'];
 }
 
 ?>
 <!doctype html>
 <html lang="en">
 <head>
-<meta charset="utf-8">
-<title>Manager Dashboard</title>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-<style>
-  body { background: #f5f6f8; }
-  .dashboard-header { position: sticky; top: 0; z-index: 1020; background: #f5f6f8; padding-top: 1rem; }
-  .filters-bar { position: sticky; top: 112px; z-index: 1010; background: #ffffff; }
-  @media (max-width: 991.98px) {
-    .filters-bar { top: 164px; }
-  }
-  .card-metric { border: none; border-radius: 1rem; box-shadow: 0 6px 24px rgba(15, 23, 42, .08); }
-  .card-metric h6 { text-transform: uppercase; font-size: .75rem; letter-spacing: .08em; margin-bottom: .5rem; color: #64748b; }
-  .tab-content .table { font-size: .875rem; }
-  .status-pill { display: inline-flex; align-items: center; justify-content: center; padding: .35rem .75rem; border-radius: 999px; font-size: .75rem; font-weight: 600; }
-  .legend-dot { width: .75rem; height: .75rem; border-radius: 50%; display: inline-block; margin-right: .35rem; }
-  .legend-item { font-size: .75rem; color: #64748b; }
-  .table thead th { text-transform: uppercase; font-size: .7rem; letter-spacing: .05em; color: #94a3b8; border-bottom: 2px solid #e2e8f0; }
-  .table tbody td { vertical-align: middle; }
-  .filters-card { border-radius: 1rem; box-shadow: 0 4px 16px rgba(15, 23, 42, .06); }
-  .filters-toolbar { display: flex; flex-wrap: wrap; align-items: flex-end; gap: .75rem 1rem; }
-  .filters-toolbar .filter-field { min-width: 140px; flex: 1 1 160px; }
-  .filters-toolbar .filter-actions { margin-left: auto; display: flex; gap: .5rem; flex-wrap: wrap; }
-  @media (max-width: 575.98px) {
-    .filters-toolbar .filter-actions { width: 100%; justify-content: flex-end; }
-  }
-  .outlet-selector-button { padding: .55rem .75rem; border-radius: .75rem; }
-  .outlet-selector-button span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .dropdown-menu.outlet-selector-menu { min-width: 16rem; max-height: 16rem; overflow: auto; }
-  .dropdown-menu.outlet-selector-menu .form-check { padding-left: 1.75rem; }
-</style>
+  <meta charset="utf-8">
+  <title>Manager Dashboard</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body { background-color: #f5f6f8; }
+    .summary-card { border-radius: 1rem; border: none; box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08); }
+    .summary-card h6 { font-size: .75rem; text-transform: uppercase; letter-spacing: .08em; color: #64748b; margin-bottom: .4rem; }
+    .summary-card .value { font-size: 1.75rem; font-weight: 700; }
+    .status-chip { display: inline-flex; align-items: center; gap: .35rem; padding: .25rem .75rem; border-radius: 999px; font-size: .75rem; font-weight: 600; text-transform: uppercase; }
+    .table-smaller td, .table-smaller th { vertical-align: middle; }
+    .filter-chip { display: inline-flex; align-items: center; background: #e2e8f0; border-radius: 999px; padding: .25rem .75rem; font-size: .75rem; margin-right: .5rem; }
+  </style>
 </head>
 <body>
 <nav class="navbar navbar-expand-lg bg-white shadow-sm">
@@ -420,297 +228,259 @@ function status_badge_class(string $status): string
 </nav>
 
 <main class="container py-4">
-  <div class="dashboard-header">
-    <div class="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-4">
-      <div>
-        <h1 class="h3 mb-2">Manager Dashboard</h1>
-        <p class="text-muted mb-0">One place to track submissions, batches, and remittances.</p>
-      </div>
-      <div class="nav nav-pills gap-2" role="tablist">
-        <a class="btn btn-sm <?= $tab === 'submissions' ? 'btn-primary' : 'btn-outline-primary' ?>" href="?tab=submissions">Submissions</a>
-        <a class="btn btn-sm <?= $tab === 'hq' ? 'btn-primary' : 'btn-outline-primary' ?>" href="?tab=hq">HQ Batches</a>
-        <a class="btn btn-sm <?= $tab === 'remittances' ? 'btn-primary' : 'btn-outline-primary' ?>" href="?tab=remittances">Cash &amp; Remittances</a>
+  <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
+    <div>
+      <h1 class="h3 mb-1">Manager Dashboard</h1>
+      <p class="text-muted mb-0">Monitor daily submissions, Pass to Office, and cash on hand in one glance.</p>
+    </div>
+    <div class="text-lg-end">
+      <div class="small text-muted">Showing <?= htmlspecialchars($dateFrom) ?> → <?= htmlspecialchars($dateTo) ?> · <?= htmlspecialchars($selectedOutletSummary) ?></div>
+    </div>
+  </div>
+
+  <?php if ($flashOk || $flashError): ?>
+    <div aria-live="polite" aria-atomic="true" class="position-relative">
+      <div class="toast-container position-fixed top-0 end-0 p-3" style="z-index:1100;">
+        <?php if ($flashOk): ?>
+          <div class="toast align-items-center text-bg-success border-0" role="alert" data-bs-delay="6000" data-bs-autohide="true" data-bs-animation="true">
+            <div class="d-flex">
+              <div class="toast-body"><?= nl2br(htmlspecialchars($flashOk)) ?></div>
+              <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>
+          </div>
+        <?php endif; ?>
+        <?php if ($flashError): ?>
+          <div class="toast align-items-center text-bg-danger border-0" role="alert" data-bs-delay="8000" data-bs-autohide="true" data-bs-animation="true">
+            <div class="d-flex">
+              <div class="toast-body"><?= nl2br(htmlspecialchars($flashError)) ?></div>
+              <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>
+          </div>
+        <?php endif; ?>
       </div>
     </div>
+  <?php endif; ?>
 
-    <div class="row g-3 mb-4">
-      <div class="col-sm-6 col-lg-3">
-        <div class="card card-metric h-100">
-          <div class="card-body">
-            <h6>Sales Approved</h6>
-            <div class="display-6 fw-semibold">RM <?= format_money($metrics['sales_approved']) ?></div>
-            <small class="text-muted">Approved sales total</small>
-          </div>
+  <?php if ($missingReceipts > 0): ?>
+    <div class="alert alert-warning d-flex align-items-center gap-2" role="alert">
+      <span class="badge text-bg-warning text-dark">Heads up</span>
+      <span><?= $missingReceipts ?> submission<?= $missingReceipts === 1 ? '' : 's' ?> missing receipts. <a class="alert-link" href="/daily_closing/manager_submissions.php?status=pending">Review now</a>.</span>
+    </div>
+  <?php endif; ?>
+
+  <form class="card border-0 shadow-sm mb-4" method="get">
+    <div class="card-body">
+      <div class="row g-3 align-items-end">
+        <div class="col-lg-4">
+          <label class="form-label text-uppercase small text-muted">Outlets</label>
+          <select name="outlets[]" id="filterOutlets" class="form-select" multiple size="5">
+            <?php foreach ($outlets as $outlet): ?>
+              <option value="<?= (int)$outlet['id'] ?>" <?= in_array((int)$outlet['id'], $selectedOutletIds, true) ? 'selected' : '' ?>>
+                <?= htmlspecialchars($outlet['name']) ?>
+              </option>
+            <?php endforeach; ?>
+          </select>
+          <div class="form-text">Hold Ctrl (Cmd on Mac) to select multiple.</div>
+        </div>
+        <div class="col-6 col-lg-2">
+          <label class="form-label text-uppercase small text-muted">Date from</label>
+          <input type="date" name="date_from" value="<?= htmlspecialchars($dateFrom) ?>" class="form-control">
+        </div>
+        <div class="col-6 col-lg-2">
+          <label class="form-label text-uppercase small text-muted">Date to</label>
+          <input type="date" name="date_to" value="<?= htmlspecialchars($dateTo) ?>" class="form-control">
+        </div>
+        <div class="col-lg-2">
+          <label class="form-label text-uppercase small text-muted">Status</label>
+          <select name="status" class="form-select">
+            <?php foreach ($statusOptions as $key => $option): ?>
+              <option value="<?= htmlspecialchars($key) ?>" <?= $key === $selectedStatus ? 'selected' : '' ?>><?= htmlspecialchars($option['label']) ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div class="col-lg-2 d-grid gap-2">
+          <button class="btn btn-primary" type="submit">Apply filters</button>
+          <a class="btn btn-outline-secondary" href="/daily_closing/views/manager/dashboard.php">Clear</a>
         </div>
       </div>
-      <div class="col-sm-6 col-lg-3">
-        <div class="card card-metric h-100">
-          <div class="card-body">
-            <h6>Expenses Approved</h6>
-            <div class="display-6 fw-semibold">RM <?= format_money($metrics['expenses_approved']) ?></div>
-            <small class="text-muted">Approved expense total</small>
-          </div>
+      <?php if ($appliedFilters): ?>
+        <div class="mt-3">
+          <?php foreach ($appliedFilters as $chip): ?>
+            <span class="filter-chip"><?= htmlspecialchars($chip) ?></span>
+          <?php endforeach; ?>
+        </div>
+      <?php endif; ?>
+    </div>
+  </form>
+
+  <div class="row g-3 mb-4">
+    <div class="col-sm-6">
+      <div class="card summary-card">
+        <div class="card-body">
+          <h6>Pending Cash on Hand</h6>
+          <div class="value">RM <?= format_money($cohOverall['pending']) ?></div>
+          <p class="text-muted small mb-0">Awaiting Accounts approval.</p>
         </div>
       </div>
-      <div class="col-sm-6 col-lg-3">
-        <div class="card card-metric h-100">
-          <div class="card-body">
-            <h6>Cash on Hand</h6>
-            <div class="display-6 fw-semibold">RM <?= format_money($metrics['cash_on_hand']) ?></div>
-            <small class="text-muted">Approved net - approved remittances</small>
-          </div>
-        </div>
-      </div>
-      <div class="col-sm-6 col-lg-3">
-        <div class="card card-metric h-100">
-          <div class="card-body">
-            <h6>Last Remittance</h6>
-            <?php if ($metrics['last_remittance']): ?>
-              <div class="fw-semibold mb-1">RM <?= format_money((float)$metrics['last_remittance']['amount']) ?></div>
-              <div class="text-muted small"><?= htmlspecialchars($metrics['last_remittance']['received_at']) ?> ·
-                <span class="badge text-bg-<?= status_badge_class((string)$metrics['last_remittance']['status']) ?>"><?= htmlspecialchars(ucfirst($metrics['last_remittance']['status'])) ?></span>
-              </div>
-            <?php else: ?>
-              <div class="fw-semibold mb-1">No remittances</div>
-              <div class="text-muted small">Record your first HQ deposit</div>
-            <?php endif; ?>
-          </div>
+    </div>
+    <div class="col-sm-6">
+      <div class="card summary-card">
+        <div class="card-body">
+          <h6>Posted Cash on Hand</h6>
+          <div class="value">RM <?= format_money($cohOverall['posted']) ?></div>
+          <p class="text-muted small mb-0">Approved &amp; posted by Accounts.</p>
         </div>
       </div>
     </div>
   </div>
 
-  <section class="filters-bar mb-4 border rounded-4 p-3 bg-white">
-    <form class="filters-toolbar w-100" method="get">
-      <input type="hidden" name="tab" value="<?= htmlspecialchars($tab) ?>">
-      <input type="hidden" name="action" value="apply">
-
-      <div class="filter-field flex-grow-1 flex-lg-grow-0">
-        <label class="form-label small text-uppercase text-muted">Date range</label>
-        <select class="form-select form-select-sm" name="range">
-          <?php foreach ($rangeOptions as $value => $label): ?>
-            <option value="<?= $value ?>" <?= ($currentFilters['range'] ?? 'week') === $value ? 'selected' : '' ?>><?= htmlspecialchars($label) ?></option>
-          <?php endforeach; ?>
-        </select>
-      </div>
-
-      <div class="filter-field flex-grow-1 flex-lg-grow-0">
-        <label class="form-label small text-uppercase text-muted">Outlets</label>
-        <div class="dropdown w-100" data-bs-auto-close="outside" data-filter-outlets data-outlet-count="<?= count($availableOutletIds) ?>">
-          <button class="btn btn-outline-secondary w-100 d-flex align-items-center justify-content-between outlet-selector-button" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-            <span id="outletSelectorLabel" class="me-2 flex-grow-1 text-start text-truncate small fw-semibold"><?= htmlspecialchars($selectedOutletSummary) ?></span>
-            <span class="text-muted small">▾</span>
-          </button>
-          <div class="dropdown-menu outlet-selector-menu w-100 shadow-sm p-3">
-            <?php if ($outlets): ?>
-              <?php foreach ($outlets as $outlet): ?>
-                <?php $outletId = (int)$outlet['id']; ?>
-                <div class="form-check mb-2">
-                  <input class="form-check-input" type="checkbox" name="outlets[]" value="<?= $outletId ?>" id="filter-outlet-<?= $outletId ?>" data-label="<?= htmlspecialchars($outlet['name']) ?>" <?= in_array($outletId, $selectedOutletIds, true) ? 'checked' : '' ?>>
-                  <label class="form-check-label" for="filter-outlet-<?= $outletId ?>"><?= htmlspecialchars($outlet['name']) ?></label>
-                </div>
-              <?php endforeach; ?>
-              <div class="d-flex align-items-center gap-2 pt-1 border-top mt-2 pt-2">
-                <button type="button" class="btn btn-link btn-sm px-0" data-action="select-all">Select all</button>
-                <span class="text-muted">·</span>
-                <button type="button" class="btn btn-link btn-sm px-0" data-action="clear">Clear</button>
-              </div>
-            <?php else: ?>
-              <span class="text-muted small">No outlets assigned yet.</span>
-            <?php endif; ?>
-          </div>
+  <div class="row g-3 mb-5">
+    <div class="col-sm-6 col-lg-3">
+      <div class="card summary-card h-100">
+        <div class="card-body">
+          <h6>Today&apos;s Sales</h6>
+          <div class="value">RM <?= format_money($todayMetrics['income']) ?></div>
+          <div class="text-muted small">vs yesterday <?= $yesterdayMetrics['income'] === 0.0 ? '—' : 'RM ' . format_money($todayMetrics['income'] - $yesterdayMetrics['income']) ?></div>
         </div>
       </div>
-
-      <div class="filter-field flex-grow-1 flex-lg-grow-0">
-        <label class="form-label small text-uppercase text-muted">Status</label>
-        <select class="form-select form-select-sm" name="status">
-          <?php foreach ($statusOptions[$tab] as $value => $label): ?>
-            <option value="<?= htmlspecialchars($value) ?>" <?= ($currentFilters['status'] ?? 'all') === $value ? 'selected' : '' ?>><?= htmlspecialchars($label) ?></option>
-          <?php endforeach; ?>
-        </select>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+      <div class="card summary-card h-100">
+        <div class="card-body">
+          <h6>Today&apos;s Expenses</h6>
+          <div class="value">RM <?= format_money($todayMetrics['expenses']) ?></div>
+          <div class="text-muted small">vs yesterday <?= $yesterdayMetrics['expenses'] === 0.0 ? '—' : 'RM ' . format_money($todayMetrics['expenses'] - $yesterdayMetrics['expenses']) ?></div>
+        </div>
       </div>
-
-      <div class="filter-field flex-grow-1 flex-lg-grow-0">
-        <label class="form-label small text-uppercase text-muted">From</label>
-        <input type="date" class="form-control form-control-sm" name="date_from" value="<?= htmlspecialchars($currentFilters['date_from'] ?? '') ?>">
+    </div>
+    <div class="col-sm-6 col-lg-3">
+      <div class="card summary-card h-100">
+        <div class="card-body">
+          <h6>Pass to Office Today</h6>
+          <div class="value">RM <?= format_money($todayMetrics['pass_to_office']) ?></div>
+          <div class="text-muted small">Across <?= count($selectedOutletIds) ?> outlet<?= count($selectedOutletIds) === 1 ? '' : 's' ?></div>
+        </div>
       </div>
-
-      <div class="filter-field flex-grow-1 flex-lg-grow-0">
-        <label class="form-label small text-uppercase text-muted">To</label>
-        <input type="date" class="form-control form-control-sm" name="date_to" value="<?= htmlspecialchars($currentFilters['date_to'] ?? '') ?>">
+    </div>
+    <div class="col-sm-6 col-lg-3">
+      <div class="card summary-card h-100">
+        <div class="card-body">
+          <h6>Pending COH (Filtered)</h6>
+          <div class="value">RM <?= format_money($rangeMetrics['pending']) ?></div>
+          <div class="text-muted small">For selected filters</div>
+        </div>
       </div>
+    </div>
+  </div>
 
-      <div class="filter-actions">
-        <button type="submit" class="btn btn-primary btn-sm px-3">Apply</button>
-        <a class="btn btn-outline-secondary btn-sm px-3" href="?tab=<?= htmlspecialchars($tab) ?>&amp;action=reset">Reset</a>
+  <div class="row g-3 mb-4">
+    <div class="col-sm-6 col-lg-3">
+      <div class="card summary-card h-100">
+        <div class="card-body">
+          <h6>Approved Sales (Filtered)</h6>
+          <div class="value">RM <?= format_money($postedRange['income']) ?></div>
+          <div class="text-muted small">Approved within range</div>
+        </div>
       </div>
-    </form>
-  </section>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+      <div class="card summary-card h-100">
+        <div class="card-body">
+          <h6>Approved Expenses</h6>
+          <div class="value">RM <?= format_money($postedRange['expenses']) ?></div>
+          <div class="text-muted small">Approved within range</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+      <div class="card summary-card h-100">
+        <div class="card-body">
+          <h6>Pass to Office Posted</h6>
+          <div class="value">RM <?= format_money($postedRange['pass_to_office']) ?></div>
+          <div class="text-muted small">Included in approved submissions</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-3">
+      <div class="card summary-card h-100">
+        <div class="card-body">
+          <h6>Posted COH (Filtered)</h6>
+          <div class="value">RM <?= format_money($postedRange['posted']) ?></div>
+          <div class="text-muted small">After Accounts approval</div>
+        </div>
+      </div>
+    </div>
+  </div>
 
-  <div class="tab-content">
-    <div class="tab-pane fade <?= $tab === 'submissions' ? 'show active' : '' ?>" id="tab-submissions" role="tabpanel">
-      <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
-        <h2 class="h5 mb-0">Recent Submissions</h2>
-        <a class="btn btn-primary" href="/daily_closing/views/manager_submission_create.php">New Submission</a>
+  <div class="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-3">
+    <div class="d-flex flex-wrap gap-2">
+      <a class="btn btn-primary" href="/daily_closing/views/manager_submission_create.php">New Submission</a>
+      <div class="d-inline-flex align-items-center gap-2 small text-muted">
+        <span class="badge text-bg-secondary">Drafts <?= $statusCounts['draft'] ?? 0 ?></span>
+        <span class="badge text-bg-info text-dark">Submitted <?= ($statusCounts['pending'] ?? 0) ?></span>
+        <span class="badge text-bg-success">Approved <?= ($statusCounts['approved'] ?? 0) ?></span>
       </div>
-      <?php if (!$availableOutletIds): ?>
-        <div class="alert alert-info">No outlets assigned yet. Contact HQ to get started.</div>
-      <?php elseif (!$submissions): ?>
-        <div class="card border-0 shadow-sm">
-          <div class="card-body text-center py-5">
-            <h5 class="mb-2">No submissions found</h5>
-            <p class="text-muted">Try a wider date range or create a new submission.</p>
-            <a class="btn btn-primary" href="/daily_closing/views/manager_submission_create.php">Create Submission</a>
-          </div>
+    </div>
+    <div>
+      <a class="btn btn-outline-primary" href="/daily_closing/views/report_hq.php">Build HQ Batch</a>
+    </div>
+  </div>
+
+  <div class="card border-0 shadow-sm mb-5">
+    <div class="card-body">
+      <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+        <div>
+          <h2 class="h5 mb-0">Recent activity</h2>
+          <p class="text-muted small mb-0">Latest 25 submissions based on filters.</p>
+        </div>
+        <a class="btn btn-sm btn-outline-secondary" href="/daily_closing/manager_submissions.php">Open full list</a>
+      </div>
+      <?php if (!$activityRows): ?>
+        <div class="text-center text-muted py-5">
+          <div class="fs-5 mb-2">No submissions yet.</div>
+          <p class="mb-3">Create your first daily submission to see activity here.</p>
+          <a class="btn btn-primary" href="/daily_closing/views/manager_submission_create.php">Create submission</a>
         </div>
       <?php else: ?>
-        <div class="table-responsive rounded-4 shadow-sm">
-          <table class="table align-middle mb-0">
-            <thead>
+        <div class="table-responsive">
+          <table class="table table-hover table-smaller align-middle mb-0">
+            <thead class="text-uppercase text-muted small">
               <tr>
-                <th>ID</th>
                 <th>Date</th>
                 <th>Outlet</th>
-                <th>Items</th>
-                <th class="text-end">Net (RM)</th>
+                <th class="text-end">Sales (RM)</th>
+                <th class="text-end">Expenses (RM)</th>
+                <th class="text-end">Pass to Office (RM)</th>
+                <th class="text-end">COH Δ (RM)</th>
+                <th>Receipts</th>
                 <th>Status</th>
                 <th class="text-end">Actions</th>
               </tr>
             </thead>
             <tbody>
-              <?php foreach ($submissions as $submission): ?>
+              <?php foreach ($activityRows as $row): ?>
+                <?php $delta = (float)$row['total_income'] - (float)$row['total_expenses'] - (float)$row['pass_to_office']; ?>
                 <tr>
-                  <td>#<?= (int)$submission['id'] ?></td>
-                  <td><?= htmlspecialchars($submission['date']) ?></td>
-                  <td><?= htmlspecialchars($submission['outlet_name']) ?></td>
-                  <td><?= (int)$submission['item_count'] ?></td>
-                  <td class="text-end"><?= format_money((float)$submission['balance']) ?></td>
+                  <td><?= htmlspecialchars($row['date']) ?></td>
+                  <td><?= htmlspecialchars($row['outlet_name']) ?></td>
+                  <td class="text-end"><?= format_money((float)$row['total_income']) ?></td>
+                  <td class="text-end"><?= format_money((float)$row['total_expenses']) ?></td>
+                  <td class="text-end"><?= format_money((float)$row['pass_to_office']) ?></td>
+                  <td class="text-end">
+                    <span class="<?= $delta >= 0 ? 'text-success' : 'text-danger' ?>"><?= format_money($delta) ?></span>
+                  </td>
                   <td>
-                    <?php $status = (string)$submission['status']; ?>
-                    <span class="badge text-bg-<?= status_badge_class($status) ?> status-pill"><?= htmlspecialchars(ucfirst($status)) ?></span>
+                    <span class="badge <?= (int)$row['receipts_count'] === 0 ? 'text-bg-warning text-dark' : 'text-bg-light text-dark' ?>">
+                      📎 <?= (int)$row['receipts_count'] ?>
+                    </span>
+                  </td>
+                  <td>
+                    <span class="status-chip text-bg-<?= status_chip_class($row['status']) ?>" data-bs-toggle="tooltip" data-bs-placement="top" title="Last updated <?= htmlspecialchars($row['updated_at'] ?? '—') ?>">
+                      <?= htmlspecialchars(status_display_label($row['status'])) ?>
+                    </span>
                   </td>
                   <td class="text-end">
-                    <div class="btn-group btn-group-sm">
-                      <a class="btn btn-outline-secondary" href="/daily_closing/manager_submission_view.php?id=<?= (int)$submission['id'] ?>">View</a>
-                      <a class="btn btn-outline-secondary" href="/daily_closing/views/report_hq.php?submission_id=<?= (int)$submission['id'] ?>">Submit</a>
-                    </div>
-                  </td>
-                </tr>
-              <?php endforeach; ?>
-            </tbody>
-          </table>
-        </div>
-        <div class="d-flex flex-wrap gap-3 mt-3">
-          <span class="legend-item"><span class="legend-dot bg-warning"></span> Submitted / Pending</span>
-          <span class="legend-item"><span class="legend-dot bg-success"></span> Approved / Completed</span>
-          <span class="legend-item"><span class="legend-dot bg-danger"></span> Rejected / Declined</span>
-          <span class="legend-item"><span class="legend-dot bg-info"></span> Processing</span>
-        </div>
-      <?php endif; ?>
-    </div>
-
-    <div class="tab-pane fade <?= $tab === 'hq' ? 'show active' : '' ?>" id="tab-hq" role="tabpanel">
-      <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
-        <h2 class="h5 mb-0">HQ Batches</h2>
-        <a class="btn btn-primary" href="/daily_closing/views/report_hq.php">New HQ Batch</a>
-      </div>
-      <?php if (!$availableOutletIds): ?>
-        <div class="alert alert-info">No outlets assigned yet. Contact HQ to get started.</div>
-      <?php elseif (!$hqBatches): ?>
-        <div class="card border-0 shadow-sm">
-          <div class="card-body text-center py-5">
-            <h5 class="mb-2">No batches yet</h5>
-            <p class="text-muted">Submit a package to HQ to see it listed here.</p>
-            <a class="btn btn-primary" href="/daily_closing/views/report_hq.php">Create HQ Batch</a>
-          </div>
-        </div>
-      <?php else: ?>
-        <div class="table-responsive rounded-4 shadow-sm">
-          <table class="table align-middle mb-0">
-            <thead>
-              <tr>
-                <th>Batch</th>
-                <th>Date</th>
-                <th>Status</th>
-                <th>Outlets</th>
-                <th>Submissions</th>
-                <th class="text-end">Balance (RM)</th>
-                <th class="text-end">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              <?php foreach ($hqBatches as $batch): ?>
-                <tr>
-                  <td>#<?= (int)$batch['id'] ?></td>
-                  <td><?= htmlspecialchars($batch['report_date']) ?></td>
-                  <td><span class="badge text-bg-<?= status_badge_class((string)$batch['status']) ?> status-pill"><?= htmlspecialchars(ucfirst((string)$batch['status'])) ?></span></td>
-                  <td><?= (int)$batch['outlet_count'] ?></td>
-                  <td><?= (int)$batch['submission_count'] ?></td>
-                  <td class="text-end"><?= format_money((float)$batch['overall_balance']) ?></td>
-                  <td class="text-end">
-                    <div class="btn-group btn-group-sm">
-                      <a class="btn btn-outline-secondary" href="/daily_closing/manager_hq_batch_view.php?id=<?= (int)$batch['id'] ?>">View</a>
-                      <a class="btn btn-outline-secondary" href="/daily_closing/account_hq_package_export.php?id=<?= (int)$batch['id'] ?>">Export</a>
-                    </div>
-                  </td>
-                </tr>
-              <?php endforeach; ?>
-            </tbody>
-          </table>
-        </div>
-      <?php endif; ?>
-    </div>
-
-    <div class="tab-pane fade <?= $tab === 'remittances' ? 'show active' : '' ?>" id="tab-remittances" role="tabpanel">
-      <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
-        <h2 class="h5 mb-0">Cash &amp; Remittances</h2>
-        <a class="btn btn-primary" href="/daily_closing/views/report_hq.php">Record Pass to Office</a>
-      </div>
-      <?php if (!$availableOutletIds): ?>
-        <div class="alert alert-info">No outlets assigned yet. Contact HQ to get started.</div>
-      <?php elseif (!$remittances): ?>
-        <div class="card border-0 shadow-sm">
-          <div class="card-body text-center py-5">
-            <h5 class="mb-2">No remittances recorded</h5>
-            <p class="text-muted">Submit a cash pass or bank-in slip to view it here.</p>
-            <a class="btn btn-primary" href="/daily_closing/views/report_hq.php">Record Remittance</a>
-          </div>
-        </div>
-      <?php else: ?>
-        <div class="table-responsive rounded-4 shadow-sm">
-          <table class="table align-middle mb-0">
-            <thead>
-              <tr>
-                <th>ID</th>
-                <th>Date</th>
-                <th>Outlet</th>
-                <th>Type</th>
-                <th class="text-end">Amount (RM)</th>
-                <th>Status</th>
-                <th class="text-end">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              <?php foreach ($remittances as $remit): ?>
-                <?php
-                  $type = !empty($remit['bank_ref']) ? 'Bank In' : 'Pass to Office';
-                  $status = (string)$remit['status'];
-                ?>
-                <tr>
-                  <td>#<?= (int)$remit['id'] ?></td>
-                  <td><?= htmlspecialchars($remit['received_at']) ?></td>
-                  <td><?= htmlspecialchars($remit['outlet_name']) ?></td>
-                  <td><?= htmlspecialchars($type) ?></td>
-                  <td class="text-end"><?= format_money((float)$remit['amount']) ?></td>
-                  <td><span class="badge text-bg-<?= status_badge_class($status) ?> status-pill"><?= htmlspecialchars(ucfirst($status)) ?></span></td>
-                  <td class="text-end">
-                    <div class="btn-group btn-group-sm">
-                      <?php if (!empty($remit['submission_id'])): ?>
-                        <a class="btn btn-outline-secondary" href="/daily_closing/manager_submission_view.php?id=<?= (int)$remit['submission_id'] ?>">Submission</a>
-                      <?php endif; ?>
-                      <a class="btn btn-outline-secondary" href="/daily_closing/views/report_hq.php">Details</a>
-                    </div>
+                    <a class="btn btn-sm btn-outline-secondary" href="/daily_closing/manager_submission_view.php?id=<?= (int)$row['id'] ?>">View details</a>
                   </td>
                 </tr>
               <?php endforeach; ?>
@@ -721,50 +491,14 @@ function status_badge_class(string $status): string
     </div>
   </div>
 </main>
+
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
-  document.addEventListener('DOMContentLoaded', function () {
-    const outletDropdown = document.querySelector('[data-filter-outlets]');
-    if (!outletDropdown) {
-      return;
-    }
-
-    const outletCount = parseInt(outletDropdown.getAttribute('data-outlet-count'), 10) || 0;
-    const summaryEl = outletDropdown.querySelector('#outletSelectorLabel');
-    const checkboxes = Array.from(outletDropdown.querySelectorAll('input[type="checkbox"][name="outlets[]"]'));
-
-    const updateSummary = () => {
-      const selected = checkboxes.filter(cb => cb.checked);
-      let label = 'All outlets';
-      if (selected.length && selected.length !== outletCount) {
-        const names = selected.map(cb => cb.getAttribute('data-label'));
-        if (names.length <= 2) {
-          label = names.join(', ');
-        } else {
-          label = `${names.length} outlets selected`;
-        }
-      }
-      summaryEl.textContent = label || 'All outlets';
-    };
-
-    checkboxes.forEach(cb => cb.addEventListener('change', updateSummary));
-
-    outletDropdown.querySelectorAll('[data-action="select-all"]').forEach(button => {
-      button.addEventListener('click', function () {
-        checkboxes.forEach(cb => { cb.checked = true; });
-        updateSummary();
-      });
-    });
-
-    outletDropdown.querySelectorAll('[data-action="clear"]').forEach(button => {
-      button.addEventListener('click', function () {
-        checkboxes.forEach(cb => { cb.checked = false; });
-        updateSummary();
-      });
-    });
-
-    updateSummary();
+  document.querySelectorAll('.toast').forEach(toastEl => {
+    const toast = new bootstrap.Toast(toastEl);
+    toast.show();
   });
+  document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
 </script>
 </body>
 </html>

--- a/views/manager_hq_batch_view.php
+++ b/views/manager_hq_batch_view.php
@@ -64,8 +64,12 @@
             <div class="fs-5">RM <?= number_format((float)$batch['overall_balance'], 2) ?></div>
           </div>
           <div class="col-sm-4">
-            <div class="fw-semibold text-muted text-uppercase small">Overall Income / Expenses</div>
+            <div class="fw-semibold text-muted text-uppercase small">Income / Expenses</div>
             <div>RM <?= number_format((float)$batch['overall_total_income'], 2) ?> / RM <?= number_format((float)$batch['overall_total_expenses'], 2) ?></div>
+          </div>
+          <div class="col-sm-4">
+            <div class="fw-semibold text-muted text-uppercase small">Pass to Office</div>
+            <div class="fs-5">RM <?= number_format((float)$batch['overall_pass_to_office'], 2) ?></div>
           </div>
         </div>
         <?php if (!empty($batch['notes'])): ?>
@@ -86,9 +90,10 @@
               <thead class="text-muted text-uppercase small">
                 <tr>
                   <th>Outlet</th>
-                  <th class="text-end" style="width:160px;">Income (RM)</th>
-                  <th class="text-end" style="width:170px;">Expenses (RM)</th>
-                  <th class="text-end" style="width:150px;">Balance (RM)</th>
+                  <th class="text-end" style="width:140px;">Income (RM)</th>
+                  <th class="text-end" style="width:140px;">Expenses (RM)</th>
+                  <th class="text-end" style="width:140px;">Pass to Office (RM)</th>
+                  <th class="text-end" style="width:140px;">Balance (RM)</th>
                 </tr>
               </thead>
               <tbody>
@@ -97,6 +102,7 @@
                   <td><?= htmlspecialchars($outlet) ?></td>
                   <td class="text-end"><?= number_format($totals['income'], 2) ?></td>
                   <td class="text-end"><?= number_format($totals['expenses'], 2) ?></td>
+                  <td class="text-end"><?= number_format($totals['pass'], 2) ?></td>
                   <td class="text-end"><?= number_format($totals['balance'], 2) ?></td>
                 </tr>
               <?php endforeach; ?>
@@ -115,9 +121,10 @@
                 <th style="width:110px;">Submission</th>
                 <th style="width:130px;">Date</th>
                 <th>Outlet</th>
-                <th class="text-end" style="width:140px;">Income (RM)</th>
-                <th class="text-end" style="width:150px;">Expenses (RM)</th>
-                <th class="text-end" style="width:140px;">Balance (RM)</th>
+                <th class="text-end" style="width:130px;">Income (RM)</th>
+                <th class="text-end" style="width:130px;">Expenses (RM)</th>
+                <th class="text-end" style="width:130px;">Pass to Office (RM)</th>
+                <th class="text-end" style="width:130px;">Balance (RM)</th>
                 <th style="width:140px;">Status</th>
                 <th style="width:110px;">Link</th>
               </tr>
@@ -144,6 +151,7 @@
                   <td><?= htmlspecialchars($row['outlet_name']) ?></td>
                   <td class="text-end"><?= number_format((float)$row['total_income'], 2) ?></td>
                   <td class="text-end"><?= number_format((float)$row['total_expenses'], 2) ?></td>
+                  <td class="text-end"><?= number_format((float)$row['pass_to_office'], 2) ?></td>
                   <td class="text-end"><?= number_format((float)$row['balance'], 2) ?></td>
                   <td>
                     <span class="badge text-bg-<?= $badge ?>"><?= htmlspecialchars(ucfirst($row['status'])) ?></span>

--- a/views/manager_hq_batches.php
+++ b/views/manager_hq_batches.php
@@ -60,6 +60,7 @@
               <th>Submissions</th>
               <th class="text-end" style="width:140px;">Income (RM)</th>
               <th class="text-end" style="width:150px;">Expenses (RM)</th>
+              <th class="text-end" style="width:150px;">Pass to Office (RM)</th>
               <th class="text-end" style="width:140px;">Balance (RM)</th>
               <th style="width:150px;">Status</th>
               <th style="width:120px;">Actions</th>
@@ -90,6 +91,7 @@
               <td><?= (int)$batch['submission_count'] ?></td>
               <td class="text-end"><?= number_format((float)$batch['overall_total_income'], 2) ?></td>
               <td class="text-end"><?= number_format((float)$batch['overall_total_expenses'], 2) ?></td>
+              <td class="text-end"><?= number_format((float)$batch['overall_pass_to_office'], 2) ?></td>
               <td class="text-end"><?= number_format((float)$batch['overall_balance'], 2) ?></td>
               <td>
                 <div class="d-flex flex-column">

--- a/views/manager_submission_view.php
+++ b/views/manager_submission_view.php
@@ -54,17 +54,21 @@
           </div>
         </div>
         <div class="row mt-3 g-3">
-          <div class="col-sm-6">
+          <div class="col-sm-6 col-md-3">
             <div class="fw-semibold text-muted text-uppercase small">Outlet</div>
             <div class="fs-5"><?= htmlspecialchars($submission['outlet_name']) ?></div>
           </div>
-          <div class="col-sm-3">
+          <div class="col-sm-6 col-md-3">
             <div class="fw-semibold text-muted text-uppercase small">Date</div>
             <div class="fs-5"><?= htmlspecialchars($submission['date']) ?></div>
           </div>
-          <div class="col-sm-3">
-            <div class="fw-semibold text-muted text-uppercase small">Balance</div>
+          <div class="col-sm-6 col-md-3">
+            <div class="fw-semibold text-muted text-uppercase small">Net Balance</div>
             <div class="fs-5">RM <?= number_format((float)$submission['balance'], 2) ?></div>
+          </div>
+          <div class="col-sm-6 col-md-3">
+            <div class="fw-semibold text-muted text-uppercase small">Pass to Office</div>
+            <div class="fs-5">RM <?= number_format((float)$submission['pass_to_office'], 2) ?></div>
           </div>
         </div>
       </div>
@@ -143,16 +147,43 @@
 
       <div class="receipt-section">
         <div class="row g-3 align-items-center">
-          <div class="col-sm-6">
-            <div class="fw-semibold text-muted text-uppercase small">Net Balance</div>
-            <div class="fs-4">RM <?= number_format((float)$submission['balance'], 2) ?></div>
+          <div class="col-lg-4">
+            <div class="fw-semibold text-muted text-uppercase small">Pass to Office</div>
+            <div class="fs-4">RM <?= number_format((float)$submission['pass_to_office'], 2) ?></div>
           </div>
-          <?php if (!empty($submission['notes'])): ?>
-            <div class="col-sm-6">
-              <div class="fw-semibold text-muted text-uppercase small">Notes</div>
-              <div><?= nl2br(htmlspecialchars($submission['notes'])) ?></div>
+          <div class="col-lg-4">
+            <div class="fw-semibold text-muted text-uppercase small">Net Impact (Income − Expenses − Pass)</div>
+            <div class="fs-4">RM <?= number_format((float)$submission['net_change'], 2) ?></div>
+            <div class="text-muted small">New COH = Old COH + Net Impact</div>
+          </div>
+          <div class="col-lg-4">
+            <div class="fw-semibold text-muted text-uppercase small">Notes</div>
+            <div><?= $submission['notes'] ? nl2br(htmlspecialchars($submission['notes'])) : '<span class="text-muted">—</span>' ?></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="receipt-section">
+        <h3 class="h5">Cash on Hand</h3>
+        <div class="row g-3">
+          <div class="col-md-4">
+            <div class="border rounded-4 p-3 bg-light">
+              <div class="text-muted small text-uppercase">Old COH</div>
+              <div class="fs-4 fw-semibold">RM <?= number_format((float)$submission['coh_before'], 2) ?></div>
             </div>
-          <?php endif; ?>
+          </div>
+          <div class="col-md-4">
+            <div class="border rounded-4 p-3 bg-light">
+              <div class="text-muted small text-uppercase">Pending Adjustment</div>
+              <div class="fs-4 fw-semibold">RM <?= number_format((float)$submission['net_change'], 2) ?></div>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="border rounded-4 p-3 bg-light">
+              <div class="text-muted small text-uppercase">New COH</div>
+              <div class="fs-4 fw-semibold">RM <?= number_format((float)$submission['coh_after'], 2) ?></div>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/views/manager_submissions_list.php
+++ b/views/manager_submissions_list.php
@@ -83,6 +83,8 @@ $queryParams = $queryParams ?? [];
             <th class="text-end" style="width:140px;">Income (RM)</th>
             <th class="text-end" style="width:150px;">Expenses (RM)</th>
             <th class="text-end" style="width:140px;">Balance (RM)</th>
+            <th class="text-end" style="width:160px;">Pass to Office (RM)</th>
+            <th class="text-end" style="width:160px;">COH Change (RM)</th>
             <th style="width:120px;">Status</th>
             <th style="width:110px;">Actions</th>
           </tr>
@@ -95,6 +97,13 @@ $queryParams = $queryParams ?? [];
             <td class="text-end"><?= number_format((float)$r['total_income'],2) ?></td>
             <td class="text-end"><?= number_format((float)$r['total_expenses'],2) ?></td>
             <td class="text-end"><?= number_format((float)$r['balance'],2) ?></td>
+            <td class="text-end"><?= number_format((float)$r['pass_to_office'],2) ?></td>
+            <td class="text-end">
+              <?php $delta = (float)$r['net_cash']; ?>
+              <span class="<?= $delta >= 0 ? 'text-success' : 'text-danger' ?>">
+                <?= number_format($delta,2) ?>
+              </span>
+            </td>
             <td>
               <?php
                 $badge = match ($r['status']) {


### PR DESCRIPTION
## Summary
- introduce reusable cash metrics helper and persist Pass to Office totals on submissions and HQ batches
- redesign the manager dashboard with modern filters, cash-on-hand cards, and a streamlined activity table with receipt indicators
- require Pass to Office values on submission creation and display pending/posted COH in submission and batch views while enhancing the HQ batch builder with receipts enforcement and confirmation prompts

## Testing
- php -l manager_submission_store.php
- php -l manager_submission_view.php
- php -l manager_submissions.php
- php -l views/manager/dashboard.php
- php -l views/report_hq.php
- php -l hq_batch_store.php
- php -l manager_hq_batches.php
- php -l manager_hq_batch_view.php
- php -l views/manager_submission_create.php
- php -l views/manager_submission_view.php
- php -l views/manager_submissions_list.php
- php -l views/manager_hq_batches.php
- php -l views/manager_hq_batch_view.php

------
https://chatgpt.com/codex/tasks/task_e_68dd612ada8c832e9bd4c1cc747d554e